### PR TITLE
Remove Aphrodite dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "homepage": "https://github.com/airbnb/react-with-styles#readme",
   "devDependencies": {
     "airbnb-js-shims": "^1.0.1",
-    "aphrodite": "^0.5.0",
     "babel-cli": "^6.11.4",
     "babel-preset-airbnb": "^2.0.0",
     "babel-register": "^6.11.6",
@@ -61,5 +60,8 @@
     "global-cache": "^1.2.0",
     "has": "^1.0.1",
     "hoist-non-react-statics": "^1.2.0"
+  },
+  "optionalDependencies": {
+    "aphrodite": "^0.5.0"
   }
 }

--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -64,6 +64,12 @@ function resolve(...styles) {
   return styleInterface.resolve(styles);
 }
 
+function flush() {
+  if (styleInterface.flush) {
+    styleInterface.flush();
+  }
+}
+
 // Using globalCache in order to export a singleton. This file may be imported
 // in several places, which otherwise stomps over any registered themes and
 // resets to just the defaults.
@@ -76,5 +82,6 @@ export default globalCache.setIfMissingThenGet(
     create,
     get,
     resolve,
+    flush,
   })
 );

--- a/src/interfaces/.eslintrc
+++ b/src/interfaces/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "import/no-extraneous-dependencies": [2, {
+      "optionalDependencies": true
+    }]
+  }
+}

--- a/src/interfaces/aphroditeInterface.js
+++ b/src/interfaces/aphroditeInterface.js
@@ -1,5 +1,5 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { StyleSheet, css } from 'aphrodite';
+import { flushToStyleTag } from 'aphrodite/lib/inject';
 import has from 'has';
 
 import flatten from '../util/flatten';
@@ -72,5 +72,12 @@ export default {
       result.style = inlineStyles;
     }
     return result;
+  },
+
+  // Flushes all buffered styles to a style tag. Required for components
+  // that depend upon previous styles in the component tree (i.e.
+  // for calculating container width, including padding/margin).
+  flush() {
+    flushToStyleTag();
   },
 };

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -80,7 +80,6 @@
 
 import React, { PropTypes } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { flushToStyleTag } from 'aphrodite/lib/inject';
 
 import ThemedStyleSheet from './ThemedStyleSheet';
 
@@ -108,17 +107,15 @@ export function withStyles(
         const props = this.props;
         const { themeName } = this.context;
 
-        // TODO we need to not depend on aphrodite directly in this component.
+        // As some components will depend on previous styles in
+        // the component tree, we provide the option of flushing the
+        // buffered styles (i.e. to a style tag) **before** the rendering
+        // cycle begins.
         //
-        // Be default, Aphrodite will buffer the styles resulting from all
-        // invocations of css and flush those styles to the style tag
-        // asynchronousely after render. For components that depdend upon all
-        // previous styles in the component tree (i.e. for calculating container
-        // width, including padding/margin), we give them the option of flushing
-        // all current buffered styles to the style tag before their rendering
-        // lifecycle begins. The flushBefore option exposes this functionality.
+        // The interfaces provide the optional "flush" method which
+        // is run in turn by ThemedStyleSheet.flush.
         if (flushBefore) {
-          flushToStyleTag();
+          ThemedStyleSheet.flush();
         }
 
         const addedProps = {


### PR DESCRIPTION
to: @lencioni 

This is a naive way of removing the hard Aphrodite dependency. Swaps out withStyles `flushBefore` option for `beforeRender`, which, if provided is run as a function.

_Edit:_ Just putting ideas down in code. This is probably the easiest way to remove the dependency but not necessarily the best way.

Fixes #3 and #4 
