### PR TITLE
Add ThemeProvider as a named export from withStyles

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -81,13 +81,16 @@
 import React, { PropTypes } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
+import ThemeProvider from './ThemeProvider';
 import ThemedStyleSheet from './ThemedStyleSheet';
+
+// Add some named exports for convenience.
+export { ThemeProvider };
+export const css = ThemedStyleSheet.resolve;
 
 const contextTypes = {
   themeName: PropTypes.string,
 };
-
-export const css = ThemedStyleSheet.resolve;
 
 export function withStyles(
   styleFn,


### PR DESCRIPTION
This file is the `main` file for the package, so this is what you get
whenever you import `react-with-styles`. Since <ThemeProvider> is part
of the regular consumer public API for this, we thought it would be
convenient to also export it from here for convenience. This allows you
to write statements like:

```js
import { ThemeProvider } from 'react-with-styles';
```