### PR TITLE
Use safe-publish-latest in prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "mocha": "mocha --compilers js:babel-register,jsx:babel-register --require airbnb-js-shims --recursive test",
     "postversion": "git commit package.json CHANGELOG.md -m \"Version $npm_package_version\" && npm run tag && git push && git push --tags && npm publish",
-    "prepublish": "in-publish && npm run build || not-in-publish",
+    "prepublish": "in-publish && safe-publish-latest && npm run build || not-in-publish",
     "pretest": "npm run --silent lint",
     "preversion": "npm run test && npm run check-changelog && npm run check-only-changelog-changed",
     "tag": "git tag v$npm_package_version",
@@ -62,7 +62,8 @@
     "react": "^15.3.1",
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.3.1",
-    "rimraf": "^2.5.4"
+    "rimraf": "^2.5.4",
+    "safe-publish-latest": "^1.0.1"
   },
   "peerDependencies": {
     "react": ">=0.14"


### PR DESCRIPTION
This ensures that when you npm publish, the "latest" tag is only set for
the truly latest version.

cc: @ljharb 