### PR TITLE
Clarify usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,23 +37,28 @@ export default {
 };
 ```
 
-Register your default theme and interface. For example, if your default theme is exported by `MyDefaultTheme.js`, and you want to use Aphrodite, you can set this up in your own `ThemedStyleSheet.js` file.
+Register your default theme and interface. For example, if your default theme is exported by `MyDefaultTheme.js`, and you want to use Aphrodite, you can set this up in your own `withStyles.js` file.
 
 ```js
 import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
+import { css, withStyles } from 'react-with-styles';
 
 import MyDefaultTheme from './MyDefaultTheme';
 
 ThemedStyleSheet.registerDefaultTheme(MyDefaultTheme);
 ThemedStyleSheet.registerInterface(aphroditeInterface);
+
+export { css, withStyles, ThemedStyleSheet };
 ```
 
-In your component, use `withStyles()` to define styles and `css()` to consume them.
+It is convenient to pass through `css` and `withStyles` from `react-with-styles` here so that everywhere you use these functions you can be assured that the default theme and interface have been registered. You could likely also set this up as an initializer that is added to the top of your bundles and then use `react-with-styles` directly in your components.
+
+In your component, from our `withStyles.js` file above, use `withStyles()` to define styles and `css()` to consume them.
 
 ```jsx
 import React, { PropTypes } from 'react';
-import { css, withStyles } from 'react-with-styles';
+import { css, withStyles } from './withStyles';
 
 function MyComponent({ styles }) {
   return (
@@ -147,7 +152,7 @@ This component simply takes a `name` prop that matches a registered theme, and s
 
 ```jsx
 import React from 'react';
-import { ThemeProvider } from 'react-with-styles';
+import { ThemeProvider } from './withStyles';
 
 export default function App() {
   return (
@@ -175,7 +180,7 @@ The wrapped component will receive a `styles` prop containing the processed styl
 
 ```jsx
 import React from 'react';
-import { css, withStyles } from 'react-with-styles';
+import { css, withStyles } from './withStyles';
 
 function MyComponent({ styles }) {
   return (
@@ -197,7 +202,7 @@ Or, as a decorator:
 
 ```jsx
 import React from 'react';
-import { css, withStyles } from 'react-with-styles';
+import { css, withStyles } from './withStyles';
 
 @withStyles(({ color, unit }) => ({
   container: {
@@ -223,7 +228,7 @@ By default, `withStyles()` will pass down the styles to the wrapped component in
 
 ```jsx
 import React from 'react';
-import { css, withStyles } from 'react-with-styles';
+import { css, withStyles } from './withStyles';
 
 function MyComponent({ withStylesStyles }) {
   return (
@@ -247,7 +252,7 @@ Likewise, the theme prop name can also be customized by setting the `themePropNa
 
 ```jsx
 import React from 'react';
-import { css, withStyles } from 'react-with-styles';
+import { css, withStyles } from './withStyles';
 
 function MyComponent({ styles, withStylesTheme }) {
   return (
@@ -278,7 +283,7 @@ This function takes styles that were processed by `withStyles()`, plain objects,
 
 ```jsx
 import React from 'react';
-import { css, withStyles } from 'react-with-styles';
+import { css, withStyles } from './withStyles';
 
 function MyComponent({ bold, padding, styles }) {
   return (


### PR DESCRIPTION
This documentation didn't make it very clear how the initialization fit
together with actual usage. This commit is an attempt at straightening
this out, which should help folks get started with using
react-with-styles.

Fixes #19.