### PR TITLE
Add documentation for including styles that use the value of a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,35 @@ export default withStyles(({ color, unit }) => ({
 
 `className` and `style` props must not be used on the same elements as `css()`.
 
+### Using the value of a prop / high cardinality
+
+To include styles that use the value of a prop (or any other styles that have a high cardinality and shouldn't be in a themed stylesheet), you can use inline styles in conjunction with `withstyles()`. 
+
+```jsx
+function MyComponent({ bold, padding, styles }) {
+  const {
+    backgroundImageUrl,
+  } = this.props;
+  
+  return (
+    <div 
+      {...css(
+        styles.container, 
+        { backgroundImage: `url(${backgroundImageUrl})` }
+      )}
+    >
+      Try to be a rainbow in{' '}
+      <a
+        href="/somewhere"
+        {...css(styles.link, bold && styles.link_bold)}
+      >
+        someone's cloud
+      </a>
+    </div>
+  );
+}
+```
+
 ## In the wild
 
 [Organizations and projects using `react-with-styles`](INTHEWILD.md).


### PR DESCRIPTION
The current documentation doesn't clearly call out the use of inline styles in the cases where the value comes from a prop, which can lead to implementations that attempt to use the "style" prop along with "withStyles" and violate the style guide.

The example provided is consistent with the best practices detailed in the style guide: https://github.com/airbnb/javascript/tree/master/css-in-javascript#inline

To: @lencioni 