### PR TITLE
Make ThemedStyleSheet.get() safe for non-registered themes

### DIFF
--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -57,7 +57,7 @@ function registerDefaultTheme(theme) {
 }
 
 function get(name = 'default') {
-  return themes[name].theme;
+  return themes[name] && themes[name].theme;
 }
 
 function resolve(...styles) {

--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -6,6 +6,14 @@ const themes = {};
 const makeFromThemes = {};
 let internalId = 0;
 
+// Used by tests to reset the state between tests.
+export function reset() {
+  Object.keys(themes).forEach(theme => delete themes[theme]);
+  Object.keys(makeFromThemes).forEach(id => delete makeFromThemes[id]);
+  internalId = 0;
+  styleInterface = undefined;
+}
+
 function registerTheme(name, overrides) {
   const theme = deepmerge(themes.default.theme, overrides);
 

--- a/test/ThemedStyleSheet_test.js
+++ b/test/ThemedStyleSheet_test.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+
+import ThemedStyleSheet, { reset } from '../src/ThemedStyleSheet';
+
+describe('ThemedStyleSheet', () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  describe('.get()', () => {
+    it('returns undefined when there is no theme', () => {
+      expect(ThemedStyleSheet.get()).to.equal(undefined);
+      expect(ThemedStyleSheet.get('tropical')).to.equal(undefined);
+    });
+
+    it('returns the default theme by default', () => {
+      const defaultTheme = { themeName: 'default' };
+      ThemedStyleSheet.registerDefaultTheme(defaultTheme);
+
+      expect(ThemedStyleSheet.get()).to.equal(defaultTheme);
+    });
+
+    it('returns named themes', () => {
+      const defaultTheme = { themeName: 'default' };
+      ThemedStyleSheet.registerDefaultTheme(defaultTheme);
+
+      const tropicalTheme = { themeName: 'tropical' };
+      ThemedStyleSheet.registerTheme('tropical', tropicalTheme);
+
+      expect(ThemedStyleSheet.get('tropical')).to.eql(tropicalTheme);
+    });
+  });
+});

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon-sandbox';
 
-import ThemedStyleSheet from '../src/ThemedStyleSheet';
+import ThemedStyleSheet, { reset } from '../src/ThemedStyleSheet';
 import { css, withStyles } from '../src/withStyles';
 
 describe('withStyles()', () => {
@@ -16,6 +16,8 @@ describe('withStyles()', () => {
   let testInterface;
 
   beforeEach(() => {
+    reset();
+
     testInterface = {
       create() {},
       resolve() {},


### PR DESCRIPTION
If the theme we were trying to get was not registered, this method would
throw an error because we were trying to access a property of
`undefined`.