### PR TITLE
Avoid copying withStyles propTypes from wrapped component

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -63,6 +63,8 @@ export function withStyles(
     WithStyles.displayName = `withStyles(${wrappedComponentName})`;
     if (WrappedComponent.propTypes) {
       WithStyles.propTypes = deepmerge({}, WrappedComponent.propTypes);
+      delete WithStyles.propTypes[stylesPropName];
+      delete WithStyles.propTypes[themePropName];
     }
     if (WrappedComponent.defaultProps) {
       WithStyles.defaultProps = deepmerge({}, WrappedComponent.defaultProps);

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import deepmerge from 'deepmerge';
 import sinon from 'sinon-sandbox';
 
 import ThemedStyleSheet from '../src/ThemedStyleSheet';
@@ -177,12 +178,13 @@ describe('withStyles()', () => {
       expect(wrapper.prop('style')).to.eql({ color: '#990000' });
     });
 
-    it('copies over propTypes and defaultProps', () => {
-      function MyComponent({ styles }) {
-        return <div {...css(styles.foo)} />;
+    it('copies over non-withStyles propTypes and defaultProps', () => {
+      function MyComponent({ styles, theme }) {
+        return <div {...css(styles.foo)}>{theme.color.default}</div>;
       }
       MyComponent.propTypes = {
         styles: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+        theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
         foo: PropTypes.number,
       };
       MyComponent.defaultProps = {
@@ -196,7 +198,12 @@ describe('withStyles()', () => {
       }))(MyComponent);
 
       // copied
-      expect(Wrapped.propTypes).to.eql(MyComponent.propTypes);
+      const expectedPropTypes = deepmerge({}, MyComponent.propTypes);
+      delete expectedPropTypes.styles;
+      delete expectedPropTypes.theme;
+      expect(Wrapped.propTypes).to.eql(expectedPropTypes);
+      expect(MyComponent.propTypes).to.include.keys('styles', 'theme');
+
       expect(Wrapped.defaultProps).to.eql(MyComponent.defaultProps);
 
       // cloned


### PR DESCRIPTION
In 094595b64 we started copying propTypes and defaultProps from the
wrapped component up to the wrapping component. Unfortunately, we forgot
about the two props that are provided by the wrapping component (styles
and theme), which may end up in the propTypes of the wrapped component.
This caused propTypes warnings to happen.

Since these props are provided by this component, we don't expect them
to be passed in by consumers, so let's just delete them. It would be
nice if there was an easy way to forbid them at the propType level, but
I'll leave that for another time.