### PR TITLE
Add pureComponent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ export default function MyComponent({ styles }) {
 
 ### Options
 
+#### `pureComponent` (default: `false`, React 15.3.0+)
+
+By default `withStyles()` will create a component that extends `React.Component`. If you want to apply the `shouldComponentUpdate()` optimization offered by `React.PureComponent`, you can set the `pureComponent` option to `true`. Note that [`React.PureComponent` was introduced in React 15.3.0](https://github.com/facebook/react/blob/master/CHANGELOG.md#1530-july-29-2016), so this will only work if you are using that version or later.
 
 #### `stylesPropName` (default: `'styles'`)
 

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -13,20 +13,34 @@ const contextTypes = {
   themeName: PropTypes.string,
 };
 
+function baseClass(pureComponent) {
+  if (pureComponent) {
+    if (!React.PureComponent) {
+      throw new ReferenceError('withStyles() pureComponent option requires React 15.3.0 or later');
+    }
+
+    return React.PureComponent;
+  }
+
+  return React.Component;
+}
+
 export function withStyles(
   styleFn,
   {
     stylesPropName = 'styles',
     themePropName = 'theme',
     flushBefore = false,
+    pureComponent = false,
   } = {},
 ) {
   const styleDef = styleFn && ThemedStyleSheet.create(styleFn);
+  const BaseClass = baseClass(pureComponent);
 
   return function withStylesHOC(WrappedComponent) {
     // NOTE: Use a class here so components are ref-able if need be:
     // eslint-disable-next-line react/prefer-stateless-function
-    class WithStyles extends React.Component {
+    class WithStyles extends BaseClass {
       render() {
         const props = this.props;
         const { themeName } = this.context;

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -210,5 +210,29 @@ describe('withStyles()', () => {
       expect(Wrapped.propTypes).not.to.equal(MyComponent.propTypes);
       expect(Wrapped.defaultProps).not.to.equal(MyComponent.defaultProps);
     });
+
+    it('extends React.Component', () => {
+      function MyComponent() {
+        return null;
+      }
+
+      const Wrapped = withStyles(() => ({}))(MyComponent);
+      expect(Object.getPrototypeOf(Wrapped)).to.equal(React.Component);
+      expect(Object.getPrototypeOf(Wrapped.prototype)).to.equal(React.Component.prototype);
+      expect(Object.getPrototypeOf(Wrapped)).not.to.equal(React.PureComponent);
+      expect(Object.getPrototypeOf(Wrapped.prototype)).not.to.equal(React.PureComponent.prototype);
+    });
+
+    it('with the pureComponent option set, extends React.PureComponent', () => {
+      function MyComponent() {
+        return null;
+      }
+
+      const Wrapped = withStyles(() => ({}), { pureComponent: true })(MyComponent);
+      expect(Object.getPrototypeOf(Wrapped)).not.to.equal(React.Component);
+      expect(Object.getPrototypeOf(Wrapped.prototype)).not.to.equal(React.Component.prototype);
+      expect(Object.getPrototypeOf(Wrapped)).to.equal(React.PureComponent);
+      expect(Object.getPrototypeOf(Wrapped.prototype)).to.equal(React.PureComponent.prototype);
+    });
   });
 });


### PR DESCRIPTION
By default `withStyles()` will create a component that extends
`React.Component`. If you want to apply the `shouldComponentUpdate()`
optimization offered by `React.PureComponent`, you can set the
`pureComponent` option to `true`.

Obviously, you could choose to compose this HOC with `pure` from
recompose or something like it, but since this is such a small change to
make, it seems valuable enough to offer it for convenience.

This will only work if you are using React 15.3.0 or later.

@airbnb/webinfra 