### PR TITLE
Avoid work inside of render()

### DIFF
--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -120,6 +120,36 @@ describe('withStyles()', () => {
       shallow(<Wrapped />, { context: { themeName: 'tropical' } }).dive();
     });
 
+    it('reacts to changed context', () => {
+      const tropicalTheme = {
+        color: {
+          red: 'yellow',
+        },
+      };
+      ThemedStyleSheet.registerTheme('tropical', tropicalTheme);
+
+      function MyComponent() {
+        return null;
+      }
+
+      const Wrapped = withStyles(({ color }) => ({
+        foo: {
+          color: color.red,
+        },
+      }))(MyComponent);
+      const wrapper = shallow(<Wrapped />, { context: { themeName: 'default' } });
+
+      // default theme
+      expect(wrapper.state('styles'))
+        .to.eql({ foo: { color: '#990000' } });
+
+      wrapper.setContext({ themeName: 'tropical' });
+
+      // tropical theme
+      expect(wrapper.state('styles'))
+        .to.eql({ foo: { color: 'yellow' } });
+    });
+
     it('allows the styles prop name to be customized', () => {
       function MyComponent({ bar }) {
         expect(bar).to.eql({ foo: { color: '#ff0000' } });


### PR DESCRIPTION
Our HOC here is currently doing more work than is really necessary
inside of render. This can make updates slower than they need to be. To
optimize this some, I'm moving this work into the constructor and
componentWillReceiveProps to avoid unnecessarily repeating it.

@airbnb/webinfra 