### PR TITLE
Always creating style object even without passed fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- Adds empty style object when no style function is provided.
+
 ## v1.2.0
 
 - [New] Add `pureComponent` option (requires React 15.3.0+).

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -13,6 +13,8 @@ const contextTypes = {
   themeName: PropTypes.string,
 };
 
+const EMPTY_STYLES = {};
+
 function baseClass(pureComponent) {
   if (pureComponent) {
     if (!React.PureComponent) {
@@ -58,7 +60,7 @@ export function withStyles(
 
         const addedProps = {
           [themePropName]: ThemedStyleSheet.get(themeName),
-          [stylesPropName]: styleDef ? styleDef(themeName) : {},
+          [stylesPropName]: styleDef ? styleDef(themeName) : EMPTY_STYLES,
         };
 
         return <WrappedComponent {...props} {...addedProps} />;

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -58,13 +58,8 @@ export function withStyles(
 
         const addedProps = {
           [themePropName]: ThemedStyleSheet.get(themeName),
+          [stylesPropName]: styleDef ? styleDef(themeName) : {},
         };
-
-        if (styleDef) {
-          addedProps[stylesPropName] = styleDef(themeName);
-        } else {
-          addedProps[stylesPropName] = {};
-        }
 
         return <WrappedComponent {...props} {...addedProps} />;
       }

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -58,12 +58,15 @@ export function withStyles(
           ThemedStyleSheet.flush();
         }
 
-        const addedProps = {
-          [themePropName]: ThemedStyleSheet.get(themeName),
-          [stylesPropName]: styleDef ? styleDef(themeName) : EMPTY_STYLES,
-        };
-
-        return <WrappedComponent {...props} {...addedProps} />;
+        return (
+          <WrappedComponent
+            {...props}
+            {...{
+              [themePropName]: ThemedStyleSheet.get(themeName),
+              [stylesPropName]: styleDef ? styleDef(themeName) : EMPTY_STYLES,
+            }}
+          />
+        );
       }
     }
 

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -62,6 +62,8 @@ export function withStyles(
 
         if (styleDef) {
           addedProps[stylesPropName] = styleDef(themeName);
+        } else {
+          addedProps[stylesPropName] = {};
         }
 
         return <WrappedComponent {...props} {...addedProps} />;

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -99,6 +99,16 @@ describe('withStyles()', () => {
       shallow(<Wrapped />).dive();
     });
 
+    it('passes an empty styles object without a styleFn', () => {
+      function MyComponent({ styles }) {
+        expect(styles).to.eql({});
+        return null;
+      }
+
+      const Wrapped = withStyles()(MyComponent);
+      shallow(<Wrapped />).dive();
+    });
+
     it('uses the theme from context', () => {
       const tropicalTheme = {
         color: {


### PR DESCRIPTION
@lencioni 

This always provides the `style` prop, even when the style function is not defined. The benefit here being consistent props that are passed to the child.