### PR TITLE
Avoid React lifecycle overhead for wrapped functional components

### DIFF
--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -1,3 +1,4 @@
+/* eslint react/forbid-prop-types: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
@@ -66,14 +67,30 @@ describe('withStyles()', () => {
       expect(result.displayName).to.equal('withStyles(MyComponent)');
     });
 
-    it('passes the theme to the wrapped component', () => {
+    it('passes the theme to the wrapped functional component', () => {
       function MyComponent({ theme }) {
         expect(theme).to.eql(defaultTheme);
         return null;
       }
 
       const Wrapped = withStyles(() => ({}))(MyComponent);
-      shallow(<Wrapped />).dive();
+      shallow(<Wrapped />);
+    });
+
+    it('passes the theme to the wrapped class component', () => {
+      class MyComponent extends React.Component {
+        render() {
+          const { theme } = this.props;
+          expect(theme).to.eql(defaultTheme);
+          return null;
+        }
+      }
+      MyComponent.propTypes = {
+        theme: PropTypes.object.isRequired,
+      };
+
+      const Wrapped = withStyles(() => ({}))(MyComponent);
+      shallow(<Wrapped />);
     });
 
     it('allows the theme prop name to be customized', () => {
@@ -83,7 +100,7 @@ describe('withStyles()', () => {
       }
 
       const Wrapped = withStyles(() => ({}), { themePropName: 'foo' })(MyComponent);
-      shallow(<Wrapped />).dive();
+      shallow(<Wrapped />);
     });
 
     it('passes processed styles to wrapped component', () => {
@@ -97,7 +114,7 @@ describe('withStyles()', () => {
           color: color.red,
         },
       }))(MyComponent);
-      shallow(<Wrapped />).dive();
+      shallow(<Wrapped />);
     });
 
     it('passes an empty styles object without a styleFn', () => {
@@ -107,7 +124,7 @@ describe('withStyles()', () => {
       }
 
       const Wrapped = withStyles()(MyComponent);
-      shallow(<Wrapped />).dive();
+      shallow(<Wrapped />);
     });
 
     it('uses the theme from context', () => {
@@ -128,7 +145,7 @@ describe('withStyles()', () => {
           color: color.red,
         },
       }))(MyComponent);
-      shallow(<Wrapped />, { context: { themeName: 'tropical' } }).dive();
+      shallow(<Wrapped />, { context: { themeName: 'tropical' } });
     });
 
     it('allows the styles prop name to be customized', () => {
@@ -142,7 +159,7 @@ describe('withStyles()', () => {
           color: '#ff0000',
         },
       }), { stylesPropName: 'bar' })(MyComponent);
-      shallow(<Wrapped />).dive();
+      shallow(<Wrapped />);
     });
 
     it('does not flush styles before rendering', () => {
@@ -188,7 +205,7 @@ describe('withStyles()', () => {
           color: color.red,
         },
       }))(MyComponent);
-      const wrapper = shallow(<Wrapped />).dive();
+      const wrapper = shallow(<Wrapped />);
 
       expect(wrapper.prop('style')).to.eql({ color: '#990000' });
     });


### PR DESCRIPTION
Styles are used everywhere throughout a React render tree, which means
that this HOC may be used on every component being rendered. This can
potentially double the size of the React tree, so we want this HOC to be
as fast as we can possibly make it. Unfortunately, we pay a small cost
for every React component because React will run lifecycle events.

However, if we can determine that the WrappedComponent is a functional
component, we can call the function directly and avoid this overhead.
For this pass I decided to do this by checking for the existence of
`render` on the wrapped component's prototype, but there might be a
better way that I don't know about.

This type of optimization may end up being baked into React itself in
the future, at which point we won't need to do this anymore. But in the
meantime, let's make things a bit faster.

The biggest side-effect of this change is that we completely drop the
React component from the tree, which means that devtools and tests might
be a little less consistent (as you can see evidenced by no longer
needing to call `dive()` in our tests here for these wrapped functional
components). I think this is an acceptable tradeoff to make.

It also occurs to me that we can probably similarly decide to use either
a class or a functional component to wrap the component, to match the
type of component it is. This would end up breaking refs that already
exist, but it would essentially make the wrapping component more
transparent. But, I don't see any real benefits to that at this time, so
I'll leave that breaking change for another time.

@airbnb/webinfra @lelandrichardson 