### PR TITLE
Add Node 8 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 sudo: false
 node_js:
+  - "8"
   - "6"
   - "5"
   - "4"


### PR DESCRIPTION
Now that Node 8 is out, we want to run our tests on it.

@airbnb/webinfra 