### PR TITLE
Update uses of sinon.stub

### DIFF
--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -23,8 +23,8 @@ describe('withStyles()', () => {
       resolve() {},
       flush: sinon.spy(),
     };
-    sinon.stub(testInterface, 'create', styleHash => styleHash);
-    sinon.stub(testInterface, 'resolve', styles => ({
+    sinon.stub(testInterface, 'create').callsFake(styleHash => styleHash);
+    sinon.stub(testInterface, 'resolve').callsFake(styles => ({
       style: styles.reduce((result, style) => Object.assign(result, style)),
     }));
 


### PR DESCRIPTION
When running tests, I noticed some deprecation warnings:

> sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the
> public API in a future version of sinon.
>  Use stub(obj, 'meth').callsFake(fn).

@airbnb/webinfra 