### PR TITLE
Prevent package-lock.json and yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ jspm_packages
 
 # Built files
 /lib
+
+# lockfiles
+package-lock.json
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Since this is a non-app, we don't want these files being generated or
committed to this repo by accident.

@ljharb 