### PR TITLE
Export resolveNoRTL method from the interface if it exists.

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -9,6 +9,7 @@ import ThemedStyleSheet from './ThemedStyleSheet';
 // Add some named exports for convenience.
 export { ThemeProvider };
 export const css = ThemedStyleSheet.resolve;
+export const cssNoRTL = ThemedStyleSheet.resolveNoRTL || css;
 
 const contextTypes = {
   themeName: PropTypes.string,


### PR DESCRIPTION
In order to begin supporting RTL in `react-with-styles`, the `resolve` method in our interfaces will begin to default support style-flipping in CSS contexts. 

However, in some cases (right now we have identified components that animate using the style property on a component, e.g. `react-motion`/`animated.js`/etc. as an issue, but more things may come up), we may need the ability to turn off this feature. Thus, if an interface does export a `noRTL` resolve, then we want to use that. Otherwise, it will fall back to the regular `resolve`.

to: @lencioni @ljharb @airbnb/webinfra 