### PR TITLE
Export resolveNoRTL in ThemedStyleSheet

### DIFF
--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -37,6 +37,10 @@ function resolve(...styles) {
   return styleInterface.resolve(styles);
 }
 
+function resolveNoRTL(...styles) {
+  return styleInterface.resolveNoRTL(styles);
+}
+
 function flush() {
   if (styleInterface.flush) {
     styleInterface.flush();
@@ -53,6 +57,7 @@ export default globalCache.setIfMissingThenGet(
     registerInterface,
     create,
     get,
+    resolveNoRTL,
     resolve,
     flush,
   }),


### PR DESCRIPTION
Whoops! I forgot to actually export `resolveNoRTL` from the `ThemedStyleSheet` in https://github.com/airbnb/react-with-styles/pull/95. This PR fixes that.

to: @ljharb @lencioni 