### PR TITLE
Actually fall back to vanilla resolve method when resolveNoRTL does not exist

### DIFF
--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -38,7 +38,11 @@ function resolve(...styles) {
 }
 
 function resolveNoRTL(...styles) {
-  return styleInterface.resolveNoRTL(styles);
+  if (styleInterface.resolveNoRTL) {
+    return styleInterface.resolveNoRTL(styles);
+  }
+
+  return resolve(styles);
 }
 
 function flush() {

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -6,7 +6,7 @@ import ThemedStyleSheet from './ThemedStyleSheet';
 
 // Add some named exports for convenience.
 export const css = ThemedStyleSheet.resolve;
-export const cssNoRTL = ThemedStyleSheet.resolveNoRTL || css;
+export const cssNoRTL = ThemedStyleSheet.resolveNoRTL;
 
 const EMPTY_STYLES = {};
 const EMPTY_STYLES_FN = () => EMPTY_STYLES;


### PR DESCRIPTION
I have finally actually fixed https://github.com/airbnb/react-with-styles/pull/97 and https://github.com/airbnb/react-with-styles/pull/95. 

Basically I wasn't thinking things through, and while #95 never accessed the interface's `resolveNoRTL` method at all, in #97 it would never be falsey even if that method *didn't* exist. This addresses both of those problem and should finally be the real solution. :|

to: @ljharb @lencioni @airbnb/webinfra 