### PR TITLE
Export withStylesPropTypes from react-with-styles directly

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import deepmerge from 'deepmerge';
 
@@ -7,6 +8,10 @@ import ThemedStyleSheet from './ThemedStyleSheet';
 // Add some named exports for convenience.
 export const css = ThemedStyleSheet.resolve;
 export const cssNoRTL = ThemedStyleSheet.resolveNoRTL;
+export const withStylesPropTypes = {
+  styles: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+};
 
 const EMPTY_STYLES = {};
 const EMPTY_STYLES_FN = () => EMPTY_STYLES;

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -6,7 +6,7 @@ import deepmerge from 'deepmerge';
 import sinon from 'sinon-sandbox';
 
 import ThemedStyleSheet from '../src/ThemedStyleSheet';
-import { css, cssNoRTL, withStyles } from '../src/withStyles';
+import { css, cssNoRTL, withStyles, withStylesPropTypes } from '../src/withStyles';
 
 describe('withStyles()', () => {
   const defaultTheme = {
@@ -160,7 +160,7 @@ describe('withStyles()', () => {
         return <div {...css(styles.foo)} />;
       }
       MyComponent.propTypes = {
-        styles: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+        ...withStylesPropTypes,
       };
 
       const Wrapped = withStyles(({ color }) => ({
@@ -174,12 +174,13 @@ describe('withStyles()', () => {
     });
 
     it('copies over non-withStyles propTypes and defaultProps', () => {
+      // TODO: fix eslint-plugin-react bug
+      // eslint-disable-next-line react/prop-types
       function MyComponent({ styles, theme }) {
         return <div {...css(styles.foo)}>{theme.color.default}</div>;
       }
       MyComponent.propTypes = {
-        styles: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-        theme: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+        ...withStylesPropTypes,
         foo: PropTypes.number,
       };
       MyComponent.defaultProps = {


### PR DESCRIPTION
This seems to make sense as something we can spread onto prop types of components wrapped in `withStyles`.

Of course, I am getting a lint failure on one my tests that uses it and not on the other. :/

PTAL @ljharb @lencioni @gabergg