### PR TITLE
Defer StyleSheet creation to run-time

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -37,13 +37,20 @@ export function withStyles(
     pureComponent = false,
   } = {},
 ) {
-  const styleDef = styleFn ? ThemedStyleSheet.create(styleFn) : EMPTY_STYLES_FN;
+  let styleDef;
   const BaseClass = baseClass(pureComponent);
 
   return function withStylesHOC(WrappedComponent) {
     // NOTE: Use a class here so components are ref-able if need be:
     // eslint-disable-next-line react/prefer-stateless-function
     class WithStyles extends BaseClass {
+      componentWillMount() {
+        // defer StyleSheet creation to run-time
+        if (!styleDef) {
+          styleDef = styleFn ? ThemedStyleSheet.create(styleFn) : EMPTY_STYLES_FN;
+        }
+      }
+
       render() {
         // As some components will depend on previous styles in
         // the component tree, we provide the option of flushing the

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -52,12 +52,18 @@ describe('withStyles()', () => {
     expect(typeof withStyles(() => ({}))).to.equal('function');
   });
 
-  it('creates the styles', () => {
-    withStyles(() => ({}));
-    expect(testInterface.create.callCount).to.equal(1);
-  });
-
   describe('HOC', () => {
+    it('creates the styles', () => {
+      function MyComponent() {
+        return null;
+      }
+
+      const WrappedComponent = withStyles(() => ({}))(MyComponent);
+      shallow(<WrappedComponent />);
+      expect(testInterface.create.callCount).to.equal(1);
+    });
+
+
     it('has a wrapped displayName', () => {
       function MyComponent() {
         return null;


### PR DESCRIPTION
After some offline conversation about the best approach to handling specificity issues in `react-with-styles-interface-aphrodite/with-rtl`, we arrived at a three step approach that would eliminate specificity issue entirely.

* 1) In order to be able to modify built-in styles based on context, defer stylesheet creation to the constructor of the `withStyles` HOC. This will also give us the performance benefit of not calling `StyleSheet.create` for currently unrendered components (but will also slow down the first render a little bit)
2) Based on directional context, cache and create the appropriate `StyleSheet` in the constructor of the `withStyles` HOC.
3) Pass a directional `css` method down to the wrapped component as a prop. This will be a breaking change and will require that components use `props.css` instead of the `react-with-styles` export. We will initially address this change internally using a babel plugin and eventually do a sweeping codemod. The directional css method will flip or not flip inline styles depending on context --- this will necessitate an update to RWS-IA.

This is step 1 of the process.

@lencioni @garrettberg @yzimet @jasonkb
