### PR TITLE
Change node targets to LTS only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - node_js: "node"
+    - node_js: "lts/*"
       env: PRETEST=true
   allow_failures:
     - os: osx


### PR DESCRIPTION
Node 9 is breaking! D: This hopefully pegs our travis builds to only the stable versions of node.

to: @ljharb 