### PR TITLE
Add directional `StyleSheet` creation based on context

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,12 +72,14 @@
     "sinon-sandbox": "^1.0.2"
   },
   "peerDependencies": {
-    "react": ">=0.14"
+    "react": ">=0.14",
+    "react-with-direction": "^1.1.0"
   },
   "dependencies": {
     "deepmerge": "^1.5.2",
     "global-cache": "^1.2.1",
     "hoist-non-react-statics": "^2.3.1",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "react-with-direction": "^1.1.0"
   }
 }

--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -16,17 +16,25 @@ function registerInterface(interfaceToRegister) {
   styleInterface = interfaceToRegister;
 }
 
-function create(makeFromTheme) {
+function create(makeFromTheme, createWithDirection) {
   // Get an id to associate with this stylesheet
   const id = internalId;
   internalId += 1;
 
   const { theme, styles } = styleTheme;
-  styles[id] = styleInterface.create(makeFromTheme(theme));
+  styles[id] = createWithDirection(makeFromTheme(theme));
 
   makeFromThemes[id] = makeFromTheme;
 
   return () => styleTheme.styles[id];
+}
+
+function createLTR(makeFromTheme) {
+  return create(makeFromTheme, styleInterface.create);
+}
+
+function createRTL(makeFromTheme) {
+  return create(makeFromTheme, styleInterface.createRTL || styleInterface.create);
 }
 
 function get() {
@@ -59,7 +67,8 @@ export default globalCache.setIfMissingThenGet(
   () => ({
     registerTheme,
     registerInterface,
-    create,
+    create: createLTR,
+    createRTL,
     get,
     resolveNoRTL,
     resolve,

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { render, shallow } from 'enzyme';
 import deepmerge from 'deepmerge';
 import sinon from 'sinon-sandbox';
+import DirectionProvider, { DIRECTIONS } from 'react-with-direction/dist/DirectionProvider';
 
 import ThemedStyleSheet from '../src/ThemedStyleSheet';
 import { css, cssNoRTL, withStyles, withStylesPropTypes } from '../src/withStyles';
@@ -62,7 +63,6 @@ describe('withStyles()', () => {
       shallow(<WrappedComponent />);
       expect(testInterface.create.callCount).to.equal(1);
     });
-
 
     it('has a wrapped displayName', () => {
       function MyComponent() {
@@ -263,18 +263,23 @@ describe('RTL support', () => {
   let testInterface;
   let resolveStub;
   let resolveNoRTLStub;
+  let createStub;
+  let createRTLStub;
 
   beforeEach(() => {
     resolveStub = sinon.stub();
     resolveNoRTLStub = sinon.stub();
 
+    createStub = sinon.stub();
+    createRTLStub = sinon.stub();
+
     testInterface = {
-      create() {},
+      create: createStub,
+      createRTL: createRTLStub,
       resolve: resolveStub,
       resolveNoRTL: resolveNoRTLStub,
       flush: sinon.spy(),
     };
-    sinon.stub(testInterface, 'create').callsFake(styleHash => styleHash);
 
     ThemedStyleSheet.registerTheme({});
     ThemedStyleSheet.registerInterface(testInterface);
@@ -303,6 +308,46 @@ describe('RTL support', () => {
       shallow(<MyComponent />);
       expect(resolveStub.callCount).to.equal(0);
       expect(resolveNoRTLStub.callCount).to.equal(1);
+    });
+  });
+
+  describe('contextual create', () => {
+    it('calls ThemedStyleSheet.create without direction set', () => {
+      function MyComponent() {
+        return null;
+      }
+
+      const WrappedComponent = withStyles(() => ({}))(MyComponent);
+      render(<WrappedComponent />);
+      expect(testInterface.create).to.have.property('callCount', 1);
+    });
+
+    it('calls ThemedStyleSheet.create with LTR direction', () => {
+      function MyComponent() {
+        return null;
+      }
+
+      const WrappedComponent = withStyles(() => ({}))(MyComponent);
+      render(
+        <DirectionProvider direction={DIRECTIONS.LTR}>
+          <WrappedComponent />
+        </DirectionProvider>,
+      );
+      expect(testInterface.create).to.have.property('callCount', 1);
+    });
+
+    it('calls ThemedStyleSheet.createRTL with RTL direction', () => {
+      function MyComponent() {
+        return null;
+      }
+
+      const WrappedComponent = withStyles(() => ({}))(MyComponent);
+      render(
+        <DirectionProvider direction={DIRECTIONS.RTL}>
+          <WrappedComponent />
+        </DirectionProvider>,
+      );
+      expect(testInterface.createRTL).to.have.property('callCount', 1);
     });
   });
 });


### PR DESCRIPTION
This change introduces a dependency on `react-with-direction` (https://github.com/airbnb/react-with-direction) although in the actual dependencies, we only make use of the constants from that package. The idea is that if you wanted to leverage the LTR/RTL capabilities of `react-with-styles`, you would pair it with a `DirectionProvider` at the top-level. Introducing those constants as part of the `react-with-styles` package makes that relationship explicit.

If you want to continue using `react-with-styles` as is, this would not add terribly much weight and the default fallbacks would all still work as expected. 

The next step would be to add directional StyleSheet creation to our interfaces. 

From https://github.com/airbnb/react-with-styles/pull/115:

> After some offline conversation about the best approach to handling specificity issues in react-with-styles-interface-aphrodite/with-rtl, we arrived at a three step approach that would eliminate specificity issue entirely.
> 
> 1. In order to be able to modify built-in styles based on context, defer stylesheet creation to the constructor of the withStyles HOC. This will also give us the performance benefit of not calling StyleSheet.create for currently unrendered components (but will also slow down the first render a little bit)
> 2. Based on directional context, cache and create the appropriate StyleSheet in the constructor of the withStyles HOC.
> 3. Pass a directional css method down to the wrapped component as a prop. This will be a breaking change and will require that components use props.css instead of the react-with-styles export. We will initially address this change internally using a babel plugin and eventually do a sweeping codemod. The directional css method will flip or not flip inline styles depending on context --- this will necessitate an update to RWS-IA.

**This is step 2 of the process.**

@ljharb @lencioni @yzimet @garrettberg