### PR TITLE
[ThemedStyleSheet] Add option to register the theme only if changed

### DIFF
--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -5,7 +5,11 @@ let styleTheme;
 const makeFromThemes = {};
 let internalId = 0;
 
-function registerTheme(theme) {
+function registerTheme(theme, { onlyIfChanged } = {}) {
+  if (onlyIfChanged && styleTheme && styleTheme.theme === theme) {
+    return;
+  }
+
   styleTheme = {
     theme,
     styles: {},


### PR DESCRIPTION
This change creates an option for consumers to register a theme
multiple times without clobbering the styles that have already been
built for the same theme. For example, this is useful in environments
that use code splitting and may register themes in multiple places.

to @ljharb @majapw 