### PR TITLE
Adds failing test for flushBefore in SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/airbnb/react-with-styles#readme",
   "devDependencies": {
     "airbnb-js-shims": "^1.3.0",
+    "aphrodite": "^1.2.5",
     "babel-cli": "^6.26.0",
     "babel-preset-airbnb": "^2.4.0",
     "babel-register": "^6.26.0",
@@ -66,6 +67,7 @@
     "react-native": "0.42.x",
     "react-native-mock": "^0.3.1",
     "react-test-renderer": "~15.4.2",
+    "react-with-styles-interface-aphrodite": "^3.1.1",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.1",
     "sinon": "^4.1.2",

--- a/test/serverRendering_test.jsx
+++ b/test/serverRendering_test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import aphroditeInterface from 'react-with-styles-interface-aphrodite';
+import { StyleSheetServer } from 'aphrodite';
+import { expect } from 'chai';
+
+import ThemedStyleSheet from '../src/ThemedStyleSheet';
+import { css, withStyles, withStylesPropTypes } from '../src/withStyles';
+
+describe('server rendering', () => {
+  const defaultTheme = {
+    color: {
+      red: '#990000',
+    },
+  };
+
+  beforeEach(() => {
+    ThemedStyleSheet.registerTheme(defaultTheme);
+    ThemedStyleSheet.registerInterface(aphroditeInterface);
+  });
+
+  it('does not blow up on the server when using flushBefore', () => {
+    function MyComponent({ styles }) {
+      return <div {...css(styles.firstDiv)} />;
+    }
+    MyComponent.propTypes = {
+      ...withStylesPropTypes,
+    };
+
+    const Container = withStyles(({ color }) => ({
+      firstDiv: {
+        color: color.red,
+      },
+    }), { flushBefore: true })(MyComponent);
+
+    expect(() => (
+      StyleSheetServer.renderStatic(() => ReactDOMServer.renderToString(<Container />))
+    )).to.not.throw();
+  });
+});


### PR DESCRIPTION
It seems like `flushBefore` [calls](https://github.com/airbnb/react-with-styles/blob/master/src/withStyles.jsx#L80) `ThemedStyleSheet.flush();` during render which is also executed on the server. If a component that uses SSR has the `flushBefore` option set then their component will fail to server render because Aphrodite can't automatically buffer without a document.

I recommend we add an environment check before we flush just to make sure the document is available.