### PR TITLE
Send css method down as a prop instead of as a global

### DIFF
--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -32,9 +32,17 @@ function resolve(...styles) {
   return styleInterface.resolve(styles);
 }
 
-function resolveNoRTL(...styles) {
-  if (styleInterface.resolveNoRTL) {
-    return styleInterface.resolveNoRTL(styles);
+function resolveLTR(...styles) {
+  if (styleInterface.resolveLTR) {
+    return styleInterface.resolveLTR(styles);
+  }
+
+  return resolve(styles);
+}
+
+function resolveRTL(...styles) {
+  if (styleInterface.resolveRTL) {
+    return styleInterface.resolveRTL(styles);
   }
 
   return resolve(styles);
@@ -57,8 +65,9 @@ export default globalCache.setIfMissingThenGet(
     create: createLTR,
     createRTL,
     get,
-    resolveNoRTL,
     resolve,
+    resolveLTR,
+    resolveRTL,
     flush,
   }),
 );


### PR DESCRIPTION
In order to solve some problems we've seen with specificity, as well as some server-side/client-side disparities, we will be attempting to separate out RTL and LTR styles entirely. Part of this has been accomplished by splitting StyleSheet creation into RTL and LTR. The next step is to send down a directional CSS method as a prop. 

I've left in the resolve method as is... but I'm unsure if that is necessary. Should we still export it from the ThemedStyleSheet or the withStyles file? 


to: @yzimet @lencioni @garrettberg @ljharb @airbnb/webinfra 