### PR TITLE
Add back non-directional defaults

### DIFF
--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -62,9 +62,11 @@ export default globalCache.setIfMissingThenGet(
   () => ({
     registerTheme,
     registerInterface,
+    create: createLTR,
     createLTR,
     createRTL,
     get,
+    resolve: resolveLTR,
     resolveLTR,
     resolveRTL,
     flush,


### PR DESCRIPTION
This is a stop-gap for the fact that we're seeing trouble upgrading an app that has two react-with-styles package dependencies.

I think the ... real solution is to update react-dates to the latest react-with-styles (also maybe it should be a peer dep? Unclear). But this should smooth the transition. 

I will upgrade the css interface tomorrow.

to: @ljharb @lencioni 