### PR TITLE
Remove ThemedStyleSheet global cache export

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   },
   "dependencies": {
     "deepmerge": "^1.5.2",
-    "global-cache": "^1.2.1",
     "hoist-non-react-statics": "^2.3.1",
     "prop-types": "^15.6.0",
     "react-with-direction": "^1.1.0"

--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -1,5 +1,3 @@
-import globalCache from 'global-cache';
-
 let styleInterface;
 let styleTheme;
 
@@ -54,21 +52,15 @@ function flush() {
   }
 }
 
-// Using globalCache in order to export a singleton. This file may be imported
-// in several places, which otherwise stomps over any registered themes and
-// resets to just the defaults.
-export default globalCache.setIfMissingThenGet(
-  'react-with-styles ThemedStyleSheet',
-  () => ({
-    registerTheme,
-    registerInterface,
-    create: createLTR,
-    createLTR,
-    createRTL,
-    get,
-    resolve: resolveLTR,
-    resolveLTR,
-    resolveRTL,
-    flush,
-  }),
-);
+export default {
+  registerTheme,
+  registerInterface,
+  create: createLTR,
+  createLTR,
+  createRTL,
+  get,
+  resolve: resolveLTR,
+  resolveLTR,
+  resolveRTL,
+  flush,
+};


### PR DESCRIPTION
After hunting down the original reason for this addition, it looks like it was to prevent clobbering already registered themes/interfaces/styles cache in the case of contextual theming. With that removed, this is probably no longer necessary.

to: @airbnb/webinfra @lencioni @noratarano @ljharb 