### PR TITLE
Use performance.mark() and performance.measure()

### DIFF
--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -27,7 +27,31 @@ function get() {
 }
 
 function resolve(...styles) {
-  return styleInterface.resolve(styles);
+  if (
+    process.env.NODE_ENV !== 'production'
+    && typeof performance !== 'undefined'
+    && performance.mark !== undefined
+  ) {
+    performance.mark('react-with-styles.resolve.start');
+  }
+
+  const result = styleInterface.resolve(styles);
+
+  if (
+    process.env.NODE_ENV !== 'production'
+    && typeof performance !== 'undefined'
+    && performance.mark !== undefined
+  ) {
+    performance.mark('react-with-styles.resolve.end');
+
+    performance.measure(
+      '\ud83d\udc69\u200d\ud83c\udfa8 [resolve]',
+      'react-with-styles.resolve.start',
+      'react-with-styles.resolve.end',
+    );
+  }
+
+  return result;
 }
 
 function resolveLTR(...styles) {

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -53,7 +53,15 @@ export function withStyles(
   let currentThemeRTL;
   const BaseClass = baseClass(pureComponent);
 
-  function createStyles(isRTL) {
+  function createStyles(isRTL, wrappedComponentName) {
+    if (
+      process.env.NODE_ENV !== 'production'
+      && typeof performance !== 'undefined'
+      && performance.mark !== undefined
+    ) {
+      performance.mark('react-with-styles.createStyles.start');
+    }
+
     const registeredTheme = ThemedStyleSheet.get();
 
     if (isRTL) {
@@ -64,10 +72,29 @@ export function withStyles(
 
     styleDefLTR = styleFn ? ThemedStyleSheet.createLTR(styleFn) : EMPTY_STYLES_FN;
     currentThemeLTR = registeredTheme;
+
+    if (
+      process.env.NODE_ENV !== 'production'
+      && typeof performance !== 'undefined'
+      && performance.mark !== undefined
+    ) {
+      performance.mark('react-with-styles.createStyles.end');
+
+      performance.measure(
+        `\ud83d\udc69\u200d\ud83c\udfa8 withStyles(${wrappedComponentName}) [create styles]`,
+        'react-with-styles.createStyles.start',
+        'react-with-styles.createStyles.end',
+      );
+    }
+
     return styleDefLTR;
   }
 
   return function withStylesHOC(WrappedComponent) {
+    const wrappedComponentName = WrappedComponent.displayName
+      || WrappedComponent.name
+      || 'Component';
+
     // NOTE: Use a class here so components are ref-able if need be:
     // eslint-disable-next-line react/prefer-stateless-function
     class WithStyles extends BaseClass {
@@ -124,7 +151,7 @@ export function withStyles(
           return styleDef;
         }
 
-        return createStyles(isRTL);
+        return createStyles(isRTL, wrappedComponentName);
       }
 
       render() {
@@ -153,10 +180,6 @@ export function withStyles(
         );
       }
     }
-
-    const wrappedComponentName = WrappedComponent.displayName
-      || WrappedComponent.name
-      || 'Component';
 
     WithStyles.WrappedComponent = WrappedComponent;
     WithStyles.displayName = `withStyles(${wrappedComponentName})`;


### PR DESCRIPTION
It would be nice to have more insight into how react-with-styles is
performing in real world applications. We can use performance.mark() and
performance.measure() to annotate the user timing pane in Chrome's
performance devtool. I am using the same method React uses to allow this
code to be built out in production builds.

I wanted to give this its own style next to the React annotations, so I
decided to bring in an emoji: 👩‍🎨

I wanted to pass the component name down to the resolve() annotations,
but in my profiling I never actually saw that annotation appear since it
is so fast, and passing it down there would be a pain and potentially a
small performance hit, so I decided against that.

In this process, I think I found a bug in Chrome:

  https://bugs.chromium.org/p/chromium/issues/detail?id=837863

Here's an example of what this looks like in action:

<img width="527" alt="screen shot 2018-04-27 at 5 10 14 pm" src="https://user-images.githubusercontent.com/195534/39389484-ec70adb0-4a3d-11e8-83ae-cb659d6fd842.png">

Fixes #140 
