### PR TITLE
[Refactor] use `this.context` instead of constructor args directly

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -104,7 +104,7 @@ export function withStyles(
         // direction needs to be stored in state in order to trigger a rerender
         // when context changes.
         this.state = {
-          direction: context[CHANNEL] ? context[CHANNEL].getState() : defaultDirection,
+          direction: this.context[CHANNEL] ? this.context[CHANNEL].getState() : defaultDirection,
         };
       }
 


### PR DESCRIPTION
This will be more robust if someone uses `new` on the component constructor (which is weird)