### PR TITLE
Remove componentWillMount

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -108,10 +108,6 @@ export function withStyles(
         };
       }
 
-      componentWillMount() {
-        this.maybeCreateStyles();
-      }
-
       componentDidMount() {
         if (this.context[CHANNEL]) {
           // subscribe to future direction changes
@@ -155,6 +151,8 @@ export function withStyles(
       }
 
       render() {
+        const styleDef = this.maybeCreateStyles();
+
         // As some components will depend on previous styles in
         // the component tree, we provide the option of flushing the
         // buffered styles (i.e. to a style tag) **before** the rendering
@@ -165,8 +163,6 @@ export function withStyles(
         if (flushBefore) {
           ThemedStyleSheet.flush();
         }
-
-        const styleDef = this.maybeCreateStyles();
 
         return (
           <WrappedComponent


### PR DESCRIPTION
This method is deprecated in React 16.3. To prepare us for the new
world, I am removing our usage of it.

I initially thought that I should move the maybeCreateStyles() function
call into the constructor, but upon closer investigation, I'm not really
sure why this is called in componentWillMount at all, only to be called
again in render. My hunch is that this was done to make sure that the
styles were created before calling flush, but we can accomplish that by
reordering the method calls in render itself. This should improve
performance by avoiding extra work.