### PR TITLE
Move work out of render and into state

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -53,7 +53,33 @@ export function withStyles(
   let currentThemeRTL;
   const BaseClass = baseClass(pureComponent);
 
-  function createStyles(isRTL, wrappedComponentName) {
+  function getResolveMethod(direction) {
+    return direction === DIRECTIONS.LTR
+      ? ThemedStyleSheet.resolveLTR
+      : ThemedStyleSheet.resolveRTL;
+  }
+
+  function getCurrentTheme(direction) {
+    return direction === DIRECTIONS.LTR
+      ? currentThemeLTR
+      : currentThemeRTL;
+  }
+
+  function getStyleDef(direction, wrappedComponentName) {
+    const currentTheme = getCurrentTheme(direction);
+    let styleDef = direction === DIRECTIONS.LTR
+      ? styleDefLTR
+      : styleDefRTL;
+
+    const registeredTheme = ThemedStyleSheet.get();
+
+    // Return the existing styles if they've already been defined
+    // and if the theme used to create them corresponds to the theme
+    // registered with ThemedStyleSheet
+    if (styleDef && currentTheme === registeredTheme) {
+      return styleDef;
+    }
+
     if (
       process.env.NODE_ENV !== 'production'
       && typeof performance !== 'undefined'
@@ -62,16 +88,23 @@ export function withStyles(
       performance.mark('react-with-styles.createStyles.start');
     }
 
-    const registeredTheme = ThemedStyleSheet.get();
+    const isRTL = direction === DIRECTIONS.RTL;
 
     if (isRTL) {
-      styleDefRTL = styleFn ? ThemedStyleSheet.createRTL(styleFn) : EMPTY_STYLES_FN;
-      currentThemeRTL = registeredTheme;
-      return styleDefRTL;
-    }
+      styleDefRTL = styleFn
+        ? ThemedStyleSheet.createRTL(styleFn)
+        : EMPTY_STYLES_FN;
 
-    styleDefLTR = styleFn ? ThemedStyleSheet.createLTR(styleFn) : EMPTY_STYLES_FN;
-    currentThemeLTR = registeredTheme;
+      currentThemeRTL = registeredTheme;
+      styleDef = styleDefRTL;
+    } else {
+      styleDefLTR = styleFn
+        ? ThemedStyleSheet.createLTR(styleFn)
+        : EMPTY_STYLES_FN;
+
+      currentThemeLTR = registeredTheme;
+      styleDef = styleDefLTR;
+    }
 
     if (
       process.env.NODE_ENV !== 'production'
@@ -87,7 +120,14 @@ export function withStyles(
       );
     }
 
-    return styleDefLTR;
+    return styleDef;
+  }
+
+  function getState(direction, wrappedComponentName) {
+    return {
+      resolveMethod: getResolveMethod(direction),
+      styleDef: getStyleDef(direction, wrappedComponentName),
+    };
   }
 
   return function withStylesHOC(WrappedComponent) {
@@ -101,22 +141,18 @@ export function withStyles(
       constructor(props, context) {
         super(props, context);
 
-        // direction needs to be stored in state in order to trigger a rerender
-        // when context changes.
-        this.state = {
-          direction: this.context[CHANNEL] ? this.context[CHANNEL].getState() : defaultDirection,
-        };
-      }
+        const direction = this.context[CHANNEL]
+          ? this.context[CHANNEL].getState()
+          : defaultDirection;
 
-      componentWillMount() {
-        this.maybeCreateStyles();
+        this.state = getState(direction, wrappedComponentName);
       }
 
       componentDidMount() {
         if (this.context[CHANNEL]) {
           // subscribe to future direction changes
           this.channelUnsubscribe = this.context[CHANNEL].subscribe((direction) => {
-            this.setState({ direction });
+            this.setState(getState(direction, wrappedComponentName));
           });
         }
       }
@@ -125,33 +161,6 @@ export function withStyles(
         if (this.channelUnsubscribe) {
           this.channelUnsubscribe();
         }
-      }
-
-      getResolveMethod() {
-        const { direction } = this.state;
-        if (direction === DIRECTIONS.RTL) {
-          return ThemedStyleSheet.resolveRTL;
-        }
-
-        return ThemedStyleSheet.resolveLTR;
-      }
-
-      maybeCreateStyles() {
-        const { direction } = this.state;
-        const isRTL = direction === DIRECTIONS.RTL;
-
-        const styleDef = isRTL ? styleDefRTL : styleDefLTR;
-        const currentTheme = isRTL ? currentThemeRTL : currentThemeLTR;
-        const registeredTheme = ThemedStyleSheet.get();
-
-        // Return the existing styles if they've already been defined
-        // and if the theme used to create them corresponds to the theme
-        // registered with ThemedStyleSheet
-        if (styleDef && currentTheme === registeredTheme) {
-          return styleDef;
-        }
-
-        return createStyles(isRTL, wrappedComponentName);
       }
 
       render() {
@@ -166,7 +175,10 @@ export function withStyles(
           ThemedStyleSheet.flush();
         }
 
-        const styleDef = this.maybeCreateStyles();
+        const {
+          resolveMethod,
+          styleDef,
+        } = this.state;
 
         return (
           <WrappedComponent
@@ -174,7 +186,7 @@ export function withStyles(
             {...{
               [themePropName]: ThemedStyleSheet.get(),
               [stylesPropName]: styleDef(),
-              [cssPropName]: this.getResolveMethod(),
+              [cssPropName]: resolveMethod,
             }}
           />
         );


### PR DESCRIPTION
I noticed that we have been storing the direction in state, and then in
componentWillMount and render we have a bunch of logic that derifes the
styles and the resolve method from that bit of direction state. However,
these things should only change when the direction changes, so we should
be able to reduce the amount of work that needs to be done in render by
instead storing these values in state. This should improve performance
whenever a component wrapped with this HOC re-renders.

This also consolidates some of the logic, which I think makes the code a
little easier to follow.

If we decide to go in this direction, we can abandon #155