### PR TITLE
Replace deepmerge with object.assign

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["airbnb"]
+  "presets": ["airbnb"],
+  "plugins": [
+    ["transform-replace-object-assign", { "moduleSpecifier": "object.assign" }],
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -76,8 +76,8 @@
     "react-with-direction": "^1.1.0"
   },
   "dependencies": {
-    "deepmerge": "^1.5.2",
     "hoist-non-react-statics": "^2.5.0",
+    "object.assign": "^4.1.0",
     "prop-types": "^15.6.1",
     "react-with-direction": "^1.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "airbnb-js-shims": "^2.0.0",
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-replace-object-assign": "^1.0.0",
     "babel-preset-airbnb": "^2.5.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import objectAssign from 'object.assign';
 
 import { CHANNEL, DIRECTIONS } from 'react-with-direction/dist/constants';
 import brcastShape from 'react-with-direction/dist/proptypes/brcast';
@@ -199,13 +198,13 @@ export function withStyles(
     WithStyles.displayName = `withStyles(${wrappedComponentName})`;
     WithStyles.contextTypes = contextTypes;
     if (WrappedComponent.propTypes) {
-      WithStyles.propTypes = objectAssign({}, WrappedComponent.propTypes);
+      WithStyles.propTypes = { ...WrappedComponent.propTypes };
       delete WithStyles.propTypes[stylesPropName];
       delete WithStyles.propTypes[themePropName];
       delete WithStyles.propTypes[cssPropName];
     }
     if (WrappedComponent.defaultProps) {
-      WithStyles.defaultProps = objectAssign({}, WrappedComponent.defaultProps);
+      WithStyles.defaultProps = { ...WrappedComponent.defaultProps };
     }
 
     return hoistNonReactStatics(WithStyles, WrappedComponent);

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -1,7 +1,9 @@
+/* eslint react/forbid-foreign-prop-types: off */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import deepmerge from 'deepmerge';
+import objectAssign from 'object.assign';
 
 import { CHANNEL, DIRECTIONS } from 'react-with-direction/dist/constants';
 import brcastShape from 'react-with-direction/dist/proptypes/brcast';
@@ -197,13 +199,13 @@ export function withStyles(
     WithStyles.displayName = `withStyles(${wrappedComponentName})`;
     WithStyles.contextTypes = contextTypes;
     if (WrappedComponent.propTypes) {
-      WithStyles.propTypes = deepmerge({}, WrappedComponent.propTypes);
+      WithStyles.propTypes = objectAssign({}, WrappedComponent.propTypes);
       delete WithStyles.propTypes[stylesPropName];
       delete WithStyles.propTypes[themePropName];
       delete WithStyles.propTypes[cssPropName];
     }
     if (WrappedComponent.defaultProps) {
-      WithStyles.defaultProps = deepmerge({}, WrappedComponent.defaultProps);
+      WithStyles.defaultProps = objectAssign({}, WrappedComponent.defaultProps);
     }
 
     return hoistNonReactStatics(WithStyles, WrappedComponent);

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { render, shallow } from 'enzyme';
-import deepmerge from 'deepmerge';
 import sinon from 'sinon-sandbox';
 import DirectionProvider, { DIRECTIONS } from 'react-with-direction/dist/DirectionProvider';
 
@@ -341,7 +340,7 @@ describe('withStyles()', () => {
       }))(MyComponent);
 
       // copied
-      const expectedPropTypes = deepmerge({}, MyComponent.propTypes);
+      const expectedPropTypes = Object.assign({}, MyComponent.propTypes);
       delete expectedPropTypes.styles;
       delete expectedPropTypes.theme;
       delete expectedPropTypes.css;

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -340,7 +340,7 @@ describe('withStyles()', () => {
       }))(MyComponent);
 
       // copied
-      const expectedPropTypes = Object.assign({}, MyComponent.propTypes);
+      const expectedPropTypes = { ...MyComponent.propTypes };
       delete expectedPropTypes.styles;
       delete expectedPropTypes.theme;
       delete expectedPropTypes.css;


### PR DESCRIPTION
I don't see any compelling reason to keep using deepmerge here. At most
we simply need to do a shallow copy of these objects, which
Object.assign is perfect for. To keep maximum compatibility, I decided
to bring in the object.assign package for this, which defaults to the
native Object.assign.