### PR TITLE
Fix: Align peer and prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "react": ">=0.14",
-    "react-with-direction": "^1.1.0"
+    "react-with-direction": "^1.3.0"
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.2.1",


### PR DESCRIPTION
Peer dependency for react-with-direction is at a different version than the packages own dependency, causing unmet dependency warnings when installed.