### PR TITLE
Add static build flag

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -136,6 +136,10 @@ export function withStyles(
       || WrappedComponent.name
       || 'Component';
 
+    if (typeof window === 'undefined' && global.WITH_STYLES_STATIC_BUILD) {
+      getStyleDef(defaultDirection, wrappedComponentName);
+    }
+
     // NOTE: Use a class here so components are ref-able if need be:
     // eslint-disable-next-line react/prefer-stateless-function
     class WithStyles extends BaseClass {


### PR DESCRIPTION
To facilitate build-time styles extraction, it would be helpful to add an env or global variable that tells withStyles to create the stylesheet immediately, rather than waiting for the component to be rendered. 

This would make things like https://github.com/airbnb/react-dates/blob/master/scripts/renderAllComponents.jsx simpler; rather than having to actually render a bunch of components (and dealing with passing down correct props), just require them. 