### PR TITLE
Extending Styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-with-direction": "^1.1.0"
   },
   "dependencies": {
+    "deepmerge": "^3.2.0",
     "hoist-non-react-statics": "^3.2.1",
     "object.assign": "^4.1.0",
     "prop-types": "^15.6.2",

--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -1,3 +1,5 @@
+import deepmerge from 'deepmerge';
+
 let styleInterface;
 let styleTheme;
 
@@ -9,17 +11,25 @@ function registerInterface(interfaceToRegister) {
   styleInterface = interfaceToRegister;
 }
 
-function create(makeFromTheme, createWithDirection) {
-  const styles = createWithDirection(makeFromTheme(styleTheme));
+function extendStyles(makeFromTheme, extendFromTheme = []) {
+  const baseStyle = makeFromTheme(styleTheme);
+  const extendedStyles = extendFromTheme.map(extendStyleFn => extendStyleFn(styleTheme));
+
+  return deepmerge.all([baseStyle, ...extendedStyles]);
+}
+
+function create(makeFromTheme, createWithDirection, extendFromTheme) {
+  const styles = createWithDirection(extendStyles(makeFromTheme, extendFromTheme));
+
   return () => styles;
 }
 
-function createLTR(makeFromTheme) {
-  return create(makeFromTheme, styleInterface.createLTR || styleInterface.create);
+function createLTR(makeFromTheme, extendFromTheme) {
+  return create(makeFromTheme, styleInterface.createLTR || styleInterface.create, extendFromTheme);
 }
 
-function createRTL(makeFromTheme) {
-  return create(makeFromTheme, styleInterface.createRTL || styleInterface.create);
+function createRTL(makeFromTheme, extendFromTheme) {
+  return create(makeFromTheme, styleInterface.createRTL || styleInterface.create, extendFromTheme);
 }
 
 function get() {

--- a/src/withExtendStyles.jsx
+++ b/src/withExtendStyles.jsx
@@ -1,0 +1,46 @@
+/* eslint react/forbid-foreign-prop-types: off */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import hoistNonReactStatics from 'hoist-non-react-statics';
+
+export default function withExtendStyles(
+  extendStyleFn,
+  {
+    extendStyleFnPropName = '_extendStyleFn',
+  } = {},
+) {
+  return function withExtendStylesHOC(WrappedComponent) {
+    const wrappedComponentName = WrappedComponent.displayName
+      || WrappedComponent.name
+      || 'Component';
+
+    const WithExtendStyles = ({ [extendStyleFnPropName]: extendStyleFns, ...rest }) => (
+      <WrappedComponent
+        {...rest}
+        {...{
+          [extendStyleFnPropName]: [
+            ...(extendStyleFn ? [extendStyleFn] : []),
+            ...(extendStyleFns || []),
+          ],
+        }}
+      />
+    );
+
+    WithExtendStyles.WrappedComponent = WrappedComponent;
+    WithExtendStyles.displayName = `withExtendStyles(${wrappedComponentName})`;
+    if (WrappedComponent.propTypes) {
+      WithExtendStyles.propTypes = {
+        [extendStyleFnPropName]: PropTypes.arrayOf(
+          PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+        ),
+        ...WrappedComponent.propTypes,
+      };
+    }
+    if (WrappedComponent.defaultProps) {
+      WithExtendStyles.defaultProps = { ...WrappedComponent.defaultProps };
+    }
+
+    return hoistNonReactStatics(WithExtendStyles, WrappedComponent);
+  };
+}

--- a/test/withExtendStyles_test.jsx
+++ b/test/withExtendStyles_test.jsx
@@ -1,0 +1,325 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from 'enzyme';
+import sinon from 'sinon-sandbox';
+import DirectionProvider, { DIRECTIONS } from 'react-with-direction/dist/DirectionProvider';
+
+import ThemedStyleSheet from '../src/ThemedStyleSheet';
+import withExtendStyles from '../src/withExtendStyles';
+import { withStyles } from '../src/withStyles';
+
+describe('withExtendStyles()', () => {
+  const defaultTheme = {
+    color: {
+      red: '#990000',
+      blue: '#334CFF',
+    },
+  };
+
+  let testInterface;
+
+  beforeEach(() => {
+    testInterface = {
+      create() {},
+      createLTR() {},
+      createRTL() {},
+      resolve() {},
+      resolveLTR() {},
+      resolveRTL() {},
+      flush: sinon.spy(),
+    };
+    sinon.stub(testInterface, 'create').callsFake(styleHash => styleHash);
+    sinon.stub(testInterface, 'createLTR').callsFake(styleHash => styleHash);
+    sinon.stub(testInterface, 'createRTL').callsFake(styleHash => styleHash);
+    const fakeResolveMethod = styles => ({
+      style: styles.reduce((result, style) => Object.assign(result, style)),
+    });
+    sinon.stub(testInterface, 'resolve').callsFake(fakeResolveMethod);
+    sinon.stub(testInterface, 'resolveLTR')
+      .callsFake(fakeResolveMethod);
+    sinon.stub(testInterface, 'resolveRTL')
+      .callsFake(fakeResolveMethod);
+
+    ThemedStyleSheet.registerTheme(defaultTheme);
+    ThemedStyleSheet.registerInterface(testInterface);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates the styles in a non-directional context', () => {
+    function MyComponent() {
+      return null;
+    }
+
+    const WrappedComponent = withStyles(() => ({}))(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles(() => ({}))(WrappedComponent);
+    render(<WrappedComponentWithExtendedStyles />);
+
+    expect(testInterface.createLTR.callCount).to.equal(1);
+  });
+
+  it('creates the styles in an LTR context', () => {
+    function MyComponent() {
+      return null;
+    }
+
+    const WrappedComponent = withStyles(() => ({}))(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles(() => ({}))(WrappedComponent);
+    render((
+      <DirectionProvider direction={DIRECTIONS.LTR}>
+        <WrappedComponentWithExtendedStyles />
+      </DirectionProvider>
+    ));
+    expect(testInterface.createLTR.callCount).to.equal(1);
+  });
+
+  it('creates the styles in an RTL context', () => {
+    function MyComponent() {
+      return null;
+    }
+
+    const WrappedComponent = withStyles(() => ({}))(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles(() => ({}))(WrappedComponent);
+    render((
+      <DirectionProvider direction={DIRECTIONS.RTL}>
+        <WrappedComponentWithExtendedStyles />
+      </DirectionProvider>
+    ));
+    expect(testInterface.createRTL.callCount).to.equal(1);
+  });
+
+  it('extends base styles', () => {
+    function MyComponent() {
+      return null;
+    }
+
+    const WrappedComponent = withStyles(() => ({
+      container: {
+        background: 'red',
+        color: 'blue',
+      },
+    }))(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles(() => ({
+      container: {
+        background: 'green',
+      },
+    }))(WrappedComponent);
+    render(
+      <WrappedComponentWithExtendedStyles />,
+    );
+
+    expect(testInterface.createLTR.callCount).to.equal(1);
+    expect(testInterface.createLTR.getCall(0).args[0]).to.eql({
+      container: {
+        background: 'green',
+        color: 'blue',
+      },
+    });
+  });
+
+  it('extends base styles (multiple classes)', () => {
+    function MyComponent() {
+      return null;
+    }
+
+    const WrappedComponent = withStyles(() => ({
+      container: {
+        background: 'red',
+        color: 'blue',
+      },
+      innerContainer: {
+        background: 'white',
+        border: '1px solid black',
+      },
+      content: {
+        fontSize: '25px',
+      },
+    }))(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles(() => ({
+      container: {
+        background: 'green',
+      },
+      innerContainer: {
+        border: '10px solid green',
+      },
+      content: {
+        fontSize: '12px',
+      },
+    }))(WrappedComponent);
+    render(
+      <WrappedComponentWithExtendedStyles />,
+    );
+
+    expect(testInterface.createLTR.callCount).to.equal(1);
+    expect(testInterface.createLTR.getCall(0).args[0]).to.eql({
+      container: {
+        background: 'green',
+        color: 'blue',
+      },
+      innerContainer: {
+        background: 'white',
+        border: '10px solid green',
+      },
+      content: {
+        fontSize: '12px',
+      },
+    });
+  });
+
+  it('extends base styles with multiple layers', () => {
+    function MyComponent() {
+      return null;
+    }
+
+    const WrappedComponent = withStyles(() => ({
+      container: {
+        background: 'red',
+        color: 'blue',
+        fontSize: '10px',
+      },
+    }))(MyComponent);
+
+    const WrappedComponentWithExtendedStyles = withExtendStyles(() => ({
+      container: {
+        background: 'green',
+        fontSize: '12px',
+      },
+    }))(WrappedComponent);
+
+    const WrappedComponentWithNestedCustomStyles = withExtendStyles(() => ({
+      container: {
+        fontSize: '20px',
+      },
+    }))(WrappedComponentWithExtendedStyles);
+
+    render(
+      <WrappedComponentWithNestedCustomStyles />,
+    );
+
+    expect(testInterface.createLTR.callCount).to.equal(1);
+    expect(testInterface.createLTR.getCall(0).args[0]).to.eql({
+      container: {
+        background: 'green',
+        color: 'blue',
+        fontSize: '20px',
+      },
+    });
+  });
+
+  it('uses original base styles if no extended styles are provided', () => {
+    function MyComponent() {
+      return null;
+    }
+
+    const WrappedComponent = withStyles(() => ({
+      container: {
+        background: 'red',
+        color: 'blue',
+      },
+    }))(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles(() => ({}))(WrappedComponent);
+    render(
+      <WrappedComponentWithExtendedStyles />,
+    );
+
+    expect(testInterface.createLTR.callCount).to.equal(1);
+    expect(testInterface.createLTR.getCall(0).args[0]).to.eql({
+      container: {
+        background: 'red',
+        color: 'blue',
+      },
+    });
+  });
+
+  it('receives the registered theme in the extend style function', (done) => {
+    function MyComponent() {
+      return null;
+    }
+
+    const WrappedComponent = withStyles(() => ({}))(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles((theme) => {
+      expect(theme).to.equal(defaultTheme);
+      done();
+      return {};
+    })(WrappedComponent);
+    render(
+      <WrappedComponentWithExtendedStyles />,
+    );
+  });
+
+  it('allows the extend styles prop name to be customized', () => {
+    function MyComponent() {
+      return null;
+    }
+
+    const WrappedComponent = withStyles(
+      () => ({
+        container: {
+          background: 'red',
+          color: 'blue',
+        },
+      }),
+      { extendStyleFnPropName: 'foobar' },
+    )(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles(
+      () => ({
+        container: {
+          background: 'pink',
+        },
+      }),
+      { extendStyleFnPropName: 'foobar' },
+    )(WrappedComponent);
+    render(
+      <WrappedComponentWithExtendedStyles />,
+    );
+
+    expect(testInterface.createLTR.callCount).to.equal(1);
+    expect(testInterface.createLTR.getCall(0).args[0]).to.eql({
+      container: {
+        background: 'pink',
+        color: 'blue',
+      },
+    });
+  });
+
+  it('passes the processed styles to the wrapped component', () => {
+    function MyComponent({ styles }) {
+      expect(styles).to.eql({ foo: { color: '#334CFF' } });
+      return null;
+    }
+
+    const WrappedComponent = withStyles(({ color }) => ({
+      foo: {
+        color: color.red,
+      },
+    }))(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles(({ color }) => ({
+      foo: {
+        color: color.blue,
+      },
+    }))(WrappedComponent);
+    render(<WrappedComponentWithExtendedStyles />);
+  });
+
+  it('has a wrapped displayName', () => {
+    function MyComponent() {
+      return null;
+    }
+
+    const result = withExtendStyles(() => ({}))(MyComponent);
+    expect(result.displayName).to.equal('withExtendStyles(MyComponent)');
+  });
+
+  it('hoists statics', () => {
+    function MyComponent() {
+      return null;
+    }
+    MyComponent.foo = 'bar';
+
+    const WrappedComponent = withStyles(() => ({}))(MyComponent);
+    const WrappedComponentWithExtendedStyles = withExtendStyles(() => ({}))(WrappedComponent);
+    expect(WrappedComponentWithExtendedStyles.foo).to.equal('bar');
+  });
+});

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -200,6 +200,158 @@ describe('withStyles()', () => {
       });
     });
 
+    describe('extendStyleFn', () => {
+      it('extends styles in a non-directional context', () => {
+        function MyComponent() {
+          return null;
+        }
+
+        const WrappedComponent = withStyles(() => ({
+          container: {
+            background: 'red',
+            color: 'blue',
+          },
+        }))(MyComponent);
+        render(
+          <WrappedComponent
+            _extendStyleFn={[
+              () => ({
+                container: {
+                  background: 'green',
+                },
+              }),
+            ]}
+          />,
+        );
+
+        expect(testInterface.createLTR.callCount).to.equal(1);
+        expect(testInterface.createLTR.getCall(0).args[0]).to.eql({
+          container: {
+            background: 'green',
+            color: 'blue',
+          },
+        });
+      });
+
+      it('extends styles in an LTR context', () => {
+        function MyComponent() {
+          return null;
+        }
+
+        const WrappedComponent = withStyles(() => ({
+          container: {
+            background: 'red',
+            color: 'blue',
+          },
+        }))(MyComponent);
+        render(
+          <DirectionProvider direction={DIRECTIONS.LTR}>
+            <WrappedComponent
+              _extendStyleFn={[
+                () => ({
+                  container: {
+                    background: 'green',
+                  },
+                }),
+              ]}
+            />
+          </DirectionProvider>,
+        );
+
+        expect(testInterface.createLTR.callCount).to.equal(1);
+        expect(testInterface.createLTR.getCall(0).args[0]).to.eql({
+          container: {
+            background: 'green',
+            color: 'blue',
+          },
+        });
+      });
+
+      it('extends styles in an RTL context', () => {
+        function MyComponent() {
+          return null;
+        }
+
+        const WrappedComponent = withStyles(() => ({
+          container: {
+            background: 'red',
+            color: 'blue',
+          },
+        }))(MyComponent);
+        render(
+          <DirectionProvider direction={DIRECTIONS.RTL}>
+            <WrappedComponent
+              _extendStyleFn={[
+                () => ({
+                  container: {
+                    background: 'green',
+                  },
+                }),
+              ]}
+            />
+          </DirectionProvider>,
+        );
+
+        expect(testInterface.createRTL.callCount).to.equal(1);
+        expect(testInterface.createRTL.getCall(0).args[0]).to.eql({
+          container: {
+            background: 'green',
+            color: 'blue',
+          },
+        });
+      });
+
+      it('receives the registered theme in the extend style function', (done) => {
+        function MyComponent() {
+          return null;
+        }
+
+        const WrappedComponent = withStyles(() => ({}))(MyComponent);
+        shallow(
+          <WrappedComponent
+            _extendStyleFn={[
+              (theme) => {
+                expect(theme).to.equal(defaultTheme);
+                done();
+                return {};
+              },
+            ]}
+          />,
+        );
+      });
+
+      it('allows the extendStyleFn prop name to be customized', () => {
+        function MyComponent() {
+          return null;
+        }
+
+        const WrappedComponent = withStyles(
+          () => ({}),
+          {
+            extendStyleFnPropName: 'newExtendStyleFn',
+          },
+        )(MyComponent);
+        shallow(
+          <WrappedComponent
+            newExtendStyleFn={[
+              () => ({
+                container: {
+                  background: 'green',
+                },
+              }),
+            ]}
+          />,
+        );
+
+        expect(testInterface.createLTR.callCount).to.equal(1);
+        expect(testInterface.createLTR.getCall(0).args[0]).to.eql({
+          container: {
+            background: 'green',
+          },
+        });
+      });
+    });
+
     it('has a wrapped displayName', () => {
       function MyComponent() {
         return null;
@@ -340,16 +492,12 @@ describe('withStyles()', () => {
       }))(MyComponent);
 
       // copied
-      const expectedPropTypes = { ...MyComponent.propTypes };
-      delete expectedPropTypes.styles;
-      delete expectedPropTypes.theme;
-      delete expectedPropTypes.css;
-      expect(Wrapped.propTypes).to.eql(expectedPropTypes);
-      expect(MyComponent.propTypes).to.include.keys('styles', 'theme');
+      expect(Wrapped.propTypes).to.include.keys('foo', '_extendStyleFn');
+      expect(MyComponent.propTypes).to.include.keys('styles', 'theme', 'css');
 
       expect(Wrapped.defaultProps).to.eql(MyComponent.defaultProps);
 
-      // cloned
+      // // cloned
       expect(Wrapped.propTypes).not.to.equal(MyComponent.propTypes);
       expect(Wrapped.defaultProps).not.to.equal(MyComponent.defaultProps);
     });


### PR DESCRIPTION
(Stacked Validation PR: coming soon...)

It's a common use-case to re-use a component's styles but make slight stylistic changes related to your product, business, etc. `react-with-styles` doesn't support this... until this PR! Extending styles is a common feature in css-in-js solutions ([styled-components](https://www.styled-components.com/docs/basics#extending-styles)) and provides the necessary flexibility without bloating components.


**Extending styles within reason**
Styles on a component should be extendable... within reason! We do not want to open up the entire `className` and `style` props on components, those flood gates should remain tightly sealed. When the component can be entirely re-styled, any internal changes to a component could break unknown external usages.

In order to allow a style to be extended, it must be defined in the `extendableStyles` option that gets passed to the `withStyles` call on the component.
```
withStyles(
  () => { ... },
  {
    extendableStyles: {
      container: {
        background: true,
        color: true,
        font: true,
      },
    },
  },
)(FooComponent);
```
Any styles that are later extended but are not explicitly defined here, will throw an error (in dev).


**Deeply nested extension**
It is possible to extend a component that has already been extended. This way you can build up a component level by level, slowly piecing together the styles you care about.
```
const ButtonWithColor = withExtendStyles(
  () => ({
    button: {
      color: 'white',
    },
  }),
)(Button);

const ButtonWithColorAndBackground = withExtendStyles(
  () => ({
    button: {
      background: 'black',
    },
  }),
)(ButtonWithColor);
```
Notice that `ButtonWithColorAndBackground` extends upon the already extending `ButtonWithColor`.


**API / Usage**
*Creating a Base Component*
```
import { withStyles } from 'react-with-styles';

const Button = ({ css, styles }) => (
  <button {...css(styles.button)}>Click Me</button>
)

export default withStyles(
  (theme) => ({
    button: {
      background: theme.colors.primary,
      color: theme.colors.white,
    },
  }),
  {
    extendableStyles: {
      button: {
        background: true,
      },
    },
  },
)(Button);
```

*Extend a Component's Styles*
```
import { withExtendStyles } from 'react-with-styles';
import Button from './Button';

export default withExtendStyles(
  (theme) => ({
    button: {
      background: theme.colors.secondary
    }
  }),
)(Button);
```

*Invalid Extension of Component's Styles*
```
import { withExtendStyles } from 'react-with-styles';
import Button from './Button';

export default withExtendStyles(
  (theme) => ({
    button: {
      // This will fail.
      // "color" is not defined in the Base Component's "extendableStyles"
      color: theme.colors.black,
    }
  }),
)(Button);
```
