### PR TITLE
Clear performance marks before setting

### DIFF
--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -32,6 +32,7 @@ function resolve(...styles) {
     && typeof performance !== 'undefined'
     && performance.mark !== undefined
   ) {
+    performance.clearMarks('react-with-styles.resolve.start');
     performance.mark('react-with-styles.resolve.start');
   }
 
@@ -42,6 +43,7 @@ function resolve(...styles) {
     && typeof performance !== 'undefined'
     && performance.mark !== undefined
   ) {
+    performance.clearMarks('react-with-styles.resolve.end');
     performance.mark('react-with-styles.resolve.end');
 
     performance.measure(
@@ -49,6 +51,7 @@ function resolve(...styles) {
       'react-with-styles.resolve.start',
       'react-with-styles.resolve.end',
     );
+    performance.clearMarks();
   }
 
   return result;

--- a/src/ThemedStyleSheet.js
+++ b/src/ThemedStyleSheet.js
@@ -1,6 +1,10 @@
 let styleInterface;
 let styleTheme;
 
+const START_MARK = 'react-with-styles.resolve.start';
+const END_MARK = 'react-with-styles.resolve.end';
+const MEASURE_MARK = '\ud83d\udc69\u200d\ud83c\udfa8 [resolve]';
+
 function registerTheme(theme) {
   styleTheme = theme;
 }
@@ -30,10 +34,10 @@ function resolve(...styles) {
   if (
     process.env.NODE_ENV !== 'production'
     && typeof performance !== 'undefined'
-    && performance.mark !== undefined
+    && performance.mark !== undefined && typeof performance.clearMarks === 'function'
   ) {
-    performance.clearMarks('react-with-styles.resolve.start');
-    performance.mark('react-with-styles.resolve.start');
+    performance.clearMarks(START_MARK);
+    performance.mark(START_MARK);
   }
 
   const result = styleInterface.resolve(styles);
@@ -41,17 +45,17 @@ function resolve(...styles) {
   if (
     process.env.NODE_ENV !== 'production'
     && typeof performance !== 'undefined'
-    && performance.mark !== undefined
+    && performance.mark !== undefined && typeof performance.clearMarks === 'function'
   ) {
-    performance.clearMarks('react-with-styles.resolve.end');
-    performance.mark('react-with-styles.resolve.end');
+    performance.clearMarks(END_MARK);
+    performance.mark(END_MARK);
 
     performance.measure(
-      '\ud83d\udc69\u200d\ud83c\udfa8 [resolve]',
-      'react-with-styles.resolve.start',
-      'react-with-styles.resolve.end',
+      MEASURE_MARK,
+      START_MARK,
+      END_MARK,
     );
-    performance.clearMarks();
+    performance.clearMarks(MEASURE_MARK);
   }
 
   return result;

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -86,6 +86,7 @@ export function withStyles(
       && typeof performance !== 'undefined'
       && performance.mark !== undefined
     ) {
+      performance.clearMarks('react-with-styles.createStyles.start');
       performance.mark('react-with-styles.createStyles.start');
     }
 
@@ -112,6 +113,7 @@ export function withStyles(
       && typeof performance !== 'undefined'
       && performance.mark !== undefined
     ) {
+      performance.clearMarks('react-with-styles.createStyles.end');
       performance.mark('react-with-styles.createStyles.end');
 
       performance.measure(
@@ -119,6 +121,7 @@ export function withStyles(
         'react-with-styles.createStyles.start',
         'react-with-styles.createStyles.end',
       );
+      performance.clearMarks();
     }
 
     return styleDef;

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -20,6 +20,9 @@ export const withStylesPropTypes = {
 const EMPTY_STYLES = {};
 const EMPTY_STYLES_FN = () => EMPTY_STYLES;
 
+const START_MARK = 'react-with-styles.createStyles.start';
+const END_MARK = 'react-with-styles.createStyles.end';
+
 function baseClass(pureComponent) {
   if (pureComponent) {
     if (!React.PureComponent) {
@@ -84,10 +87,10 @@ export function withStyles(
     if (
       process.env.NODE_ENV !== 'production'
       && typeof performance !== 'undefined'
-      && performance.mark !== undefined
+      && performance.mark !== undefined && typeof performance.clearMarks === 'function'
     ) {
-      performance.clearMarks('react-with-styles.createStyles.start');
-      performance.mark('react-with-styles.createStyles.start');
+      performance.clearMarks(START_MARK);
+      performance.mark(START_MARK);
     }
 
     const isRTL = direction === DIRECTIONS.RTL;
@@ -111,17 +114,19 @@ export function withStyles(
     if (
       process.env.NODE_ENV !== 'production'
       && typeof performance !== 'undefined'
-      && performance.mark !== undefined
+      && performance.mark !== undefined && typeof performance.clearMarks === 'function'
     ) {
-      performance.clearMarks('react-with-styles.createStyles.end');
-      performance.mark('react-with-styles.createStyles.end');
+      performance.clearMarks(END_MARK);
+      performance.mark(END_MARK);
+
+      const measureName = `\ud83d\udc69\u200d\ud83c\udfa8 withStyles(${wrappedComponentName}) [create styles]`;
 
       performance.measure(
-        `\ud83d\udc69\u200d\ud83c\udfa8 withStyles(${wrappedComponentName}) [create styles]`,
-        'react-with-styles.createStyles.start',
-        'react-with-styles.createStyles.end',
+        measureName,
+        START_MARK,
+        END_MARK,
       );
-      performance.clearMarks();
+      performance.clearMarks(measureName);
     }
 
     return styleDef;


### PR DESCRIPTION
I suppose that current behaviour of marking performance call freeze in Firefox in development.
https://github.com/airbnb/react-dates/issues/1359 
https://github.com/airbnb/react-dates/issues/1442