### PR TITLE
[dep] Update react-with-direction to fix hoisting

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,13 +77,13 @@
   },
   "peerDependencies": {
     "react": ">=0.14",
-    "react-with-direction": "^1.1.0"
+    "react-with-direction": "^1.3.1"
   },
   "dependencies": {
     "airbnb-prop-types": "^2.14.0",
     "hoist-non-react-statics": "^3.2.1",
     "object.assign": "^4.1.0",
     "prop-types": "^15.7.2",
-    "react-with-direction": "^1.3.0"
+    "react-with-direction": "^1.3.1"
   }
 }

--- a/src/providers/WithStylesDirectionAdapter.jsx
+++ b/src/providers/WithStylesDirectionAdapter.jsx
@@ -38,12 +38,4 @@ WithStylesDirectionAdapter.propTypes = propTypes;
 WithStylesDirectionAdapter.defaultProps = defaultProps;
 WithStylesDirectionAdapter.contextType = WithStylesContext;
 
-// eslint-disable-next-line no-underscore-dangle
-const _WithStylesDirectionAdapter = withDirection(WithStylesDirectionAdapter);
-
-// Have to remove the contextType the withDirection component hoists because
-// it's using an old version of hoist-non-react-statics that copies it over
-// TODO: remove this once withDirection updates hoist-non-react-statics
-delete _WithStylesDirectionAdapter.contextType;
-
-export default _WithStylesDirectionAdapter;
+export default withDirection(WithStylesDirectionAdapter);


### PR DESCRIPTION
### Summary

Update to version 1.3.1 of react-with-direction, which uses `hoist-non-react-statics` 3.3.0, and fixes the two versions of context issue (`contextType` used by `WithStylesDirectionAdapter` and `contextTypes` used by `witDirection()`).

### Reviewers

@ljharb  @ahuth @TaeKimJR @joeuy @indiesquidge @majapw 