### PR TITLE
[withStyles] Use WeakMap instead of Map to prevent high memory usage

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -49,7 +49,7 @@ export function withStyles(
   const BaseClass = pureComponent ? React.PureComponent : React.Component;
 
   /** Cache for storing the result of stylesFn(theme) for all themes. */
-  const stylesFnResultCacheMap = new Map();
+  const stylesFnResultCacheMap = new WeakMap();
 
   // The function that wraps the provided component in a wrapper
   // component that injects the withStyles props

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -49,7 +49,7 @@ export function withStyles(
   const BaseClass = pureComponent ? React.PureComponent : React.Component;
 
   /** Cache for storing the result of stylesFn(theme) for all themes. */
-  const stylesFnResultCacheMap = new WeakMap();
+  const stylesFnResultCacheMap = typeof WeakMap === 'undefined' ? new Map() : new WeakMap();
 
   // The function that wraps the provided component in a wrapper
   // component that injects the withStyles props


### PR DESCRIPTION
### Summary
Using WeakMap to use weak references to the keys so the cache doesn't grow out of control. This will allow those keys to get garbage collected.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap

### Reviewers
@ahuth @ljharb @indiesquidge @majapw @joeuy 