### PR TITLE
[performance] Cache by the resulting `WithStyles` HOC

### DIFF
--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -124,9 +124,7 @@ export function withStyles(
     class WithStyles extends BaseClass {
       getCurrentInterface() {
         // Fallback to the singleton implementation
-        return (
-          (this.context && this.context.stylesInterface) || _getInterface()
-        );
+        return (this.context && this.context.stylesInterface) || _getInterface();
       }
 
       getCurrentTheme() {


### PR DESCRIPTION
## Summary

1. Cache even further by the resulting `WithStyles` component so that we avoid calling create/resolve unnecessarily per component instance. Before, we were calling create once per theme, per component _instance_, per direction. This way, we're calling create once per theme, per component _definition_, per direction, which should happen less often.

2. We also refactor some class methods that didn't need to be class methods

I would especially appreciate feedback around the organization of this code for performance and clarity. Take a look at the commits for easy of review.

## Reviewers

@esprehn @TaeKimJR @joeuy @indiesquidge @ljharb @marsjosephine