### PR TITLE
[withStyles] Forward ref to inner component

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,41 @@ export default withStyles(({ color, unit }) => ({
 }))(MyComponent);
 ```
 
+### Accessing your wrapped component with a ref
+
+React 16.3 introduced the ability to pass along refs with the [`React.forwardRef`][react-forward-ref]
+helper, allowing you to write code like this.
+
+```jsx
+const MyComponent = React.forwardRef(
+  function MyComponent({ css, styles }, forwardedRef) {
+    return (
+      <div {...css(styles.container)} ref={forwardedRef}>
+        Hello, World
+      </div>
+    );
+  }
+);
+```
+
+Refs will not get passed through HOCs by default because `ref` is not a prop. If
+you add a ref to an HOC, the ref will refer to the outermost container component,
+which is usually not desired. `withStyles` is set up to pass along your ref to
+the wrapped component.
+
+```jsx
+const MyComponentWithStyles = withStyles(({ color, unit }) => ({
+  container: {
+    color: color.primary,
+    marginBottom: 2 * unit,
+  },
+}))(MyComponent);
+
+// the ref will be passed down to MyComponent, which is then attached to the div
+const ref = React.createRef()
+<MyComponentWithStyles ref={ref} />
+```
+
 ### `ThemedStyleSheet` (legacy)
 
 Registers themes and interfaces.
@@ -522,6 +557,7 @@ export default withRouter(withStyles(({ color, unit }) => ({
 
 [aphrodite]: https://github.com/khan/aphrodite
 [radium]: https://formidable.com/open-source/radium/
+[react-forward-ref]: https://reactjs.org/docs/forwarding-refs.html
 [react-native]: https://facebook.github.io/react-native/
 [react-router]: https://github.com/reactjs/react-router
 [react-router-link]: https://github.com/reactjs/react-router/blob/master/docs/API.md#link

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import getComponentName from 'airbnb-prop-types/build/helpers/getComponentName';
+import ref from 'airbnb-prop-types/build/ref';
 
 import EMPTY_STYLES_FN from './utils/emptyStylesFn';
 import withPerf from './utils/perf';
@@ -232,8 +233,10 @@ export function withStyles(
 
         return (
           <WrappedComponent
-            ref={forwardedRef}
-            {...rest}
+            // TODO: remove conditional once breaking change to only support React 16.3+
+            // ref: https://github.com/airbnb/react-with-styles/pull/240#discussion_r533497857
+            ref={typeof React.forwardRef === 'undefined' ? undefined : forwardedRef}
+            {...(typeof React.forwardRef === 'undefined' ? this.props : rest)}
             {...{
               [themePropName]: theme,
               [stylesPropName]: styles,
@@ -244,9 +247,21 @@ export function withStyles(
       }
     }
 
-    const ForwardedWithStyles = React.forwardRef((props, ref) => (
-      <WithStyles {...props} forwardedRef={ref} />
-    ));
+    // TODO: remove conditional once breaking change to only support React 16.3+
+    // ref: https://github.com/airbnb/react-with-styles/pull/240#discussion_r533497857
+    if (typeof React.forwardRef !== 'undefined') {
+      WithStyles.propTypes = {
+        forwardedRef: ref(),
+      };
+    }
+
+    // TODO: remove conditional once breaking change to only support React 16.3+
+    // ref: https://github.com/airbnb/react-with-styles/pull/240#discussion_r533497857
+    const ForwardedWithStyles = typeof React.forwardRef === 'undefined'
+      ? WithStyles
+      : React.forwardRef((props, forwardedRef) => (
+        <WithStyles {...props} forwardedRef={forwardedRef} />
+      ));
 
     // Copy the wrapped component's prop types and default props on WithStyles
     if (WrappedComponent.propTypes) {

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -228,9 +228,12 @@ export function withStyles(
           this.flush();
         }
 
+        const { forwardedRef, ...rest } = this.props;
+
         return (
           <WrappedComponent
-            {...this.props}
+            ref={forwardedRef}
+            {...rest}
             {...{
               [themePropName]: theme,
               [stylesPropName]: styles,
@@ -241,20 +244,25 @@ export function withStyles(
       }
     }
 
+    const ForwardedWithStyles = React.forwardRef((props, ref) => (
+      <WithStyles {...props} forwardedRef={ref} />
+    ));
+
     // Copy the wrapped component's prop types and default props on WithStyles
     if (WrappedComponent.propTypes) {
-      WithStyles.propTypes = { ...WrappedComponent.propTypes };
-      delete WithStyles.propTypes[stylesPropName];
-      delete WithStyles.propTypes[themePropName];
-      delete WithStyles.propTypes[cssPropName];
+      ForwardedWithStyles.propTypes = { ...WrappedComponent.propTypes };
+      delete ForwardedWithStyles.propTypes[stylesPropName];
+      delete ForwardedWithStyles.propTypes[themePropName];
+      delete ForwardedWithStyles.propTypes[cssPropName];
     }
     if (WrappedComponent.defaultProps) {
-      WithStyles.defaultProps = { ...WrappedComponent.defaultProps };
+      ForwardedWithStyles.defaultProps = { ...WrappedComponent.defaultProps };
     }
     WithStyles.contextType = WithStylesContext;
-    WithStyles.WrappedComponent = WrappedComponent;
-    WithStyles.displayName = `withStyles(${wrappedComponentName})`;
-    return hoistNonReactStatics(WithStyles, WrappedComponent);
+    ForwardedWithStyles.WrappedComponent = WrappedComponent;
+    ForwardedWithStyles.displayName = `withStyles(${wrappedComponentName})`;
+
+    return hoistNonReactStatics(ForwardedWithStyles, WrappedComponent);
   };
 }
 

--- a/test/withStyles_test.jsx
+++ b/test/withStyles_test.jsx
@@ -142,6 +142,18 @@ describe('withStyles', () => {
       expect(StyledComponent.defaultProps).to.have.keys('foo');
     });
 
+    it('forwards refs through to the wrapped component', () => {
+      const stylesFn = sinon.stub().callsFake(() => ({}));
+      const MockComponent = React.forwardRef((props, forwardedRef) => (
+        <div ref={forwardedRef} />
+      ));
+      const StyledComponent = withStyles(stylesFn)(MockComponent);
+      const ref = React.createRef();
+      const wrapper = mountWithProviders(<StyledComponent ref={ref} />, providers);
+      const div = wrapper.find('div').first().getDOMNode();
+      expect(div).to.equal(ref.current);
+    });
+
     describe('rendering without options (standard behavior)', () => {
       it('passes the theme to the stylesFn', () => {
         const stylesFn = sinon.stub().callsFake(() => ({}));
@@ -627,7 +639,8 @@ describe('withStyles', () => {
         const MockComponent = ({ styles, css }) => <div {...css(styles.primary)} />;
         MockComponent.propTypes = { ...withStylesPropTypes };
         const StyledComponent = withStyles(stylesFn)(MockComponent);
-        const wrapper = shallow(<StyledComponent />);
+        // dive() needed here to access the component wrapped by React.forwardRef
+        const wrapper = shallow(<StyledComponent />).dive();
         expect(stylesFn.calledWith(testTheme)).to.equal(true);
         expect(wrapper.find(MockComponent).props()).to.have.property('theme', testTheme);
       });


### PR DESCRIPTION
Refs will not get passed through withStyles by default because `ref` is not a prop. If you add a ref to an HOC, the ref will refer to the outermost container component, not the wrapped component.

Ref: https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-in-higher-order-components