### PR TITLE
Upgrade to react 16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@babel/runtime": "^7.0.0",
-    "react": ">=0.14",
+    "react": "^16.3 || ^17",
     "react-with-direction": "^1.3.1"
   },
   "dependencies": {

--- a/src/withStyles.jsx
+++ b/src/withStyles.jsx
@@ -1,9 +1,8 @@
 /* eslint-disable no-param-reassign */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import getComponentName from 'airbnb-prop-types/build/helpers/getComponentName';
-import ref from 'airbnb-prop-types/build/ref';
 
 import EMPTY_STYLES_FN from './utils/emptyStylesFn';
 import withPerf from './utils/perf';
@@ -233,10 +232,8 @@ export function withStyles(
 
         return (
           <WrappedComponent
-            // TODO: remove conditional once breaking change to only support React 16.3+
-            // ref: https://github.com/airbnb/react-with-styles/pull/240#discussion_r533497857
-            ref={typeof React.forwardRef === 'undefined' ? undefined : forwardedRef}
-            {...(typeof React.forwardRef === 'undefined' ? this.props : rest)}
+            ref={forwardedRef}
+            {...rest}
             {...{
               [themePropName]: theme,
               [stylesPropName]: styles,
@@ -247,21 +244,9 @@ export function withStyles(
       }
     }
 
-    // TODO: remove conditional once breaking change to only support React 16.3+
-    // ref: https://github.com/airbnb/react-with-styles/pull/240#discussion_r533497857
-    if (typeof React.forwardRef !== 'undefined') {
-      WithStyles.propTypes = {
-        forwardedRef: ref(),
-      };
-    }
-
-    // TODO: remove conditional once breaking change to only support React 16.3+
-    // ref: https://github.com/airbnb/react-with-styles/pull/240#discussion_r533497857
-    const ForwardedWithStyles = typeof React.forwardRef === 'undefined'
-      ? WithStyles
-      : React.forwardRef((props, forwardedRef) => (
-        <WithStyles {...props} forwardedRef={forwardedRef} />
-      ));
+    const ForwardedWithStyles = forwardRef((props, ref) => (
+      <WithStyles {...props} forwardedRef={ref} />
+    ));
 
     // Copy the wrapped component's prop types and default props on WithStyles
     if (WrappedComponent.propTypes) {


### PR DESCRIPTION
Follow-up from https://github.com/airbnb/react-with-styles/pull/240#discussion_r533497857 to create a breaking change to solidify support and peer dependency requirements on React 16.3+, chiefly to support `React.forwardRef` for this HOC.

Version 4.2.0 will be the final version to support earlier versions of React.